### PR TITLE
feat(mvp): 根据架构文档初始化MVP代码框架

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ out/
 # Signing / secrets / environment
 *.jks
 *.keystore
+*.p12
+*.pfx
+keystore.properties
 .env*
 
 # Logs / temporary files

--- a/.gitignore
+++ b/.gitignore
@@ -1,25 +1,47 @@
-*.iml
-.gradle
-/local.properties
+# IDE / Editor
+.idea/
 /.idea/caches
 /.idea/libraries
 /.idea/modules.xml
 /.idea/workspace.xml
 /.idea/navEditor.xml
 /.idea/assetWizardSettings.xml
-.DS_Store
+.vscode/
+*.iml
+
+# Android / Gradle local files
+.gradle
+.kotlin
+/local.properties
+local.properties
+gradle/gradle-daemon-jvm.properties
+
+# Build outputs
 /build
+build/
+**/build/
+out/
+*.class
+*.jar
 /captures
 .externalNativeBuild
 .cxx
-local.properties
-docs/develop
-build/
-**/build/
-.idea/
+
+# Signing / secrets / environment
 *.jks
 *.keystore
+.env*
+
+# Logs / temporary files
 *.log
-gradle/gradle-daemon-jvm.properties
-.kotlin
+*.tmp
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Local docs scratch area
+docs/develop
+
+# scripts
 opencode-webui.cmd

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,22 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import java.util.Properties
+
+val keystoreProperties =
+    Properties().apply {
+        val keystorePropertiesFile = rootProject.file("keystore.properties")
+        if (keystorePropertiesFile.exists()) {
+            keystorePropertiesFile.inputStream().use(::load)
+        }
+    }
+
+fun signingProperty(name: String): String? =
+    keystoreProperties.getProperty(name)?.takeIf { it.isNotBlank() }
+        ?: System.getenv("CHUDADI_${name.uppercase()}")?.takeIf { it.isNotBlank() }
+
+val releaseStoreFile = signingProperty("storeFile")
+val releaseStorePassword = signingProperty("storePassword")
+val releaseKeyAlias = signingProperty("keyAlias")
+val releaseKeyPassword = signingProperty("keyPassword")
 
 plugins {
     alias(libs.plugins.android.application)
@@ -30,13 +48,41 @@ android {
         }
     }
 
+    signingConfigs {
+        create("release") {
+            if (
+                releaseStoreFile != null &&
+                releaseStorePassword != null &&
+                releaseKeyAlias != null &&
+                releaseKeyPassword != null
+            ) {
+                storeFile = rootProject.file(releaseStoreFile)
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+                enableV1Signing = true
+                enableV2Signing = true
+            }
+        }
+    }
+
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+        }
+    }
+    splits {
+        abi {
+            isEnable = true
+            reset()
+            include("arm64-v8a", "armeabi-v7a")
+            isUniversalApk = false
         }
     }
     compileOptions {
@@ -52,6 +98,23 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+}
+
+val isReleaseTaskRequested =
+    gradle.startParameter.taskNames.any { taskName ->
+        taskName.contains("Release", ignoreCase = true)
+    }
+
+if (
+    isReleaseTaskRequested &&
+    (releaseStoreFile == null ||
+        releaseStorePassword == null ||
+        releaseKeyAlias == null ||
+        releaseKeyPassword == null)
+) {
+    throw GradleException(
+        "Missing release signing config. Create keystore.properties in project root (see keystore.properties.example).",
+    )
 }
 
 dependencies {

--- a/app/src/androidTest/java/com/example/chudadi/ui/GameActionFeedbackTest.kt
+++ b/app/src/androidTest/java/com/example/chudadi/ui/GameActionFeedbackTest.kt
@@ -1,0 +1,68 @@
+package com.example.chudadi.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.snapshot.MatchUiState
+import com.example.chudadi.model.game.snapshot.OpponentSummary
+import com.example.chudadi.model.game.snapshot.TablePlaySummary
+import com.example.chudadi.ui.game.GameScreenActions
+import com.example.chudadi.ui.game.GameScreen
+import org.junit.Rule
+import org.junit.Test
+
+class GameActionFeedbackTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun gameScreen_showsActionFeedbackAndDisabledButtons() {
+        composeRule.setContent {
+            GameScreen(
+                uiState =
+                    MatchUiState(
+                        phase = MatchPhase.PLAYER_TURN,
+                        playerHand = listOf(Card(rank = CardRank.THREE, suit = CardSuit.DIAMONDS)),
+                        opponentSummaries =
+                            listOf(
+                                OpponentSummary(
+                                    seatId = 1,
+                                    displayName = "AI 1",
+                                    remainingCards = 5,
+                                    isCurrentActor = false,
+                                    hasPassed = true,
+                                ),
+                            ),
+                        currentActorName = "You",
+                        currentTablePlay =
+                            TablePlaySummary(
+                                ownerSeatId = 1,
+                                ownerName = "AI 1",
+                                combinationLabel = "Single",
+                                cardLabels = listOf("5♠"),
+                            ),
+                        lastActionMessage = "当前牌不够大",
+                        canSubmitPlay = false,
+                        canPass = false,
+                        isHumanTurn = true,
+                    ),
+                actions =
+                    GameScreenActions(
+                        onToggleCardSelection = {},
+                        onClearSelection = {},
+                        onSubmitSelectedCards = {},
+                        onPassTurn = {},
+                    ),
+            )
+        }
+
+        composeRule.onNodeWithTag(ComposeTestTags.ACTION_MESSAGE).assertIsDisplayed()
+        composeRule.onNodeWithTag(ComposeTestTags.SUBMIT_BUTTON).assertIsNotEnabled()
+        composeRule.onNodeWithTag(ComposeTestTags.PASS_BUTTON).assertIsNotEnabled()
+    }
+}

--- a/app/src/androidTest/java/com/example/chudadi/ui/LocalMatchFlowTest.kt
+++ b/app/src/androidTest/java/com/example/chudadi/ui/LocalMatchFlowTest.kt
@@ -1,0 +1,28 @@
+package com.example.chudadi.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.example.chudadi.controller.game.LocalMatchViewModel
+import com.example.chudadi.navigation.ChuDaDiNavGraph
+import org.junit.Rule
+import org.junit.Test
+
+class LocalMatchFlowTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun startLocalMatch_navigatesFromHomeToGame() {
+        composeRule.setContent {
+            ChuDaDiNavGraph(viewModel = LocalMatchViewModel())
+        }
+
+        composeRule.onNodeWithTag(ComposeTestTags.HOME_SCREEN).assertIsDisplayed()
+        composeRule.onNodeWithTag(ComposeTestTags.START_MATCH_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ComposeTestTags.GAME_SCREEN).assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/example/chudadi/ui/ResultFlowTest.kt
+++ b/app/src/androidTest/java/com/example/chudadi/ui/ResultFlowTest.kt
@@ -1,0 +1,152 @@
+package com.example.chudadi.ui
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.example.chudadi.controller.game.LocalMatchViewModel
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.RoundResult
+import com.example.chudadi.model.game.entity.Seat
+import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.entity.SeatStatus
+import com.example.chudadi.model.game.entity.TrickState
+import com.example.chudadi.navigation.ChuDaDiNavGraph
+import org.junit.Rule
+import org.junit.Test
+
+class ResultFlowTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun restartFromResult_navigatesToGame() {
+        composeRule.setContent {
+            ChuDaDiNavGraph(
+                viewModel = LocalMatchViewModel(engine = ScriptedGameEngine(finishedMatch(), ongoingMatch())),
+            )
+        }
+
+        composeRule.onNodeWithTag(ComposeTestTags.START_MATCH_BUTTON).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(ComposeTestTags.RESULT_SCREEN).assertIsDisplayed()
+
+        composeRule.onNodeWithTag(ComposeTestTags.RESTART_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ComposeTestTags.GAME_SCREEN).assertIsDisplayed()
+    }
+
+    @Test
+    fun exitFromResult_navigatesBackToHome() {
+        composeRule.setContent {
+            ChuDaDiNavGraph(
+                viewModel = LocalMatchViewModel(engine = ScriptedGameEngine(finishedMatch())),
+            )
+        }
+
+        composeRule.onNodeWithTag(ComposeTestTags.START_MATCH_BUTTON).performClick()
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(ComposeTestTags.RESULT_SCREEN).assertIsDisplayed()
+
+        composeRule.onNodeWithTag(ComposeTestTags.EXIT_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(ComposeTestTags.HOME_SCREEN).assertIsDisplayed()
+    }
+
+    private class ScriptedGameEngine(
+        private vararg val scriptedMatches: Match,
+    ) : GameEngine() {
+        private var cursor = 0
+
+        override fun startLocalMatch(): Match {
+            val match = scriptedMatches[cursor.coerceAtMost(scriptedMatches.lastIndex)]
+            if (cursor < scriptedMatches.lastIndex) {
+                cursor++
+            }
+            return match
+        }
+    }
+
+    companion object {
+        private fun finishedMatch(): Match {
+            return Match(
+                matchId = "finished-match",
+                phase = MatchPhase.FINISHED,
+                seats = baseSeats(),
+                activeSeatIndex = 0,
+                trickState = TrickState(
+                    leadSeatIndex = 0,
+                    lastWinningSeatIndex = 0,
+                    currentCombination = null,
+                    passCount = 0,
+                    roundNumber = 1,
+                ),
+                playHistory = listOf("You win"),
+                result =
+                    RoundResult(
+                        winnerSeatIndex = 0,
+                        ranking = listOf(0, 1, 2, 3),
+                        summaryLines = listOf("1. You (0 cards left)"),
+                    ),
+            )
+        }
+
+        private fun ongoingMatch(): Match {
+            return Match(
+                matchId = "ongoing-match",
+                phase = MatchPhase.PLAYER_TURN,
+                seats = baseSeats(),
+                activeSeatIndex = 0,
+                trickState = TrickState(
+                    leadSeatIndex = 0,
+                    lastWinningSeatIndex = 0,
+                    currentCombination = null,
+                    passCount = 0,
+                    roundNumber = 1,
+                ),
+                playHistory = listOf("You lead"),
+                result = null,
+            )
+        }
+
+        private fun baseSeats(): List<Seat> {
+            return listOf(
+                Seat(
+                    seatId = 0,
+                    displayName = "You",
+                    controllerType = SeatControllerType.HUMAN,
+                    hand = listOf(Card(rank = CardRank.THREE, suit = CardSuit.DIAMONDS)),
+                    status = SeatStatus.ACTIVE,
+                ),
+                Seat(
+                    seatId = 1,
+                    displayName = "AI 1",
+                    controllerType = SeatControllerType.RULE_BASED_AI,
+                    hand = listOf(Card(rank = CardRank.FOUR, suit = CardSuit.CLUBS)),
+                    status = SeatStatus.ACTIVE,
+                ),
+                Seat(
+                    seatId = 2,
+                    displayName = "AI 2",
+                    controllerType = SeatControllerType.RULE_BASED_AI,
+                    hand = listOf(Card(rank = CardRank.FIVE, suit = CardSuit.HEARTS)),
+                    status = SeatStatus.ACTIVE,
+                ),
+                Seat(
+                    seatId = 3,
+                    displayName = "AI 3",
+                    controllerType = SeatControllerType.RULE_BASED_AI,
+                    hand = listOf(Card(rank = CardRank.SIX, suit = CardSuit.SPADES)),
+                    status = SeatStatus.ACTIVE,
+                ),
+            )
+        }
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
+            android:screenOrientation="landscape"
             android:theme="@style/Theme.ChuDaDi">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/example/chudadi/MainActivity.kt
+++ b/app/src/main/java/com/example/chudadi/MainActivity.kt
@@ -4,13 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.example.chudadi.navigation.ChuDaDiNavGraph
 import com.example.chudadi.ui.theme.ChuDaDiTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +13,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             ChuDaDiTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Android",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                ChuDaDiNavGraph()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    ChuDaDiTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/chudadi/ai/rulebased/RuleBasedAiPlayer.kt
+++ b/app/src/main/java/com/example/chudadi/ai/rulebased/RuleBasedAiPlayer.kt
@@ -1,0 +1,73 @@
+package com.example.chudadi.ai.rulebased
+
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.PlayCombination
+import com.example.chudadi.model.game.rule.CombinationEvaluator
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+
+sealed interface AiDecision {
+    data class Play(
+        val cardIds: Set<String>,
+    ) : AiDecision
+
+    data object Pass : AiDecision
+}
+
+class RuleBasedAiPlayer(
+    private val evaluator: CombinationEvaluator = CombinationEvaluator(),
+) {
+    fun decideAction(
+        match: Match,
+        seatIndex: Int,
+    ): AiDecision {
+        val seat = match.seats.first { it.seatId == seatIndex }
+        val currentCombination = match.trickState.currentCombination
+        val allCombinations = evaluator.generateAllValidCombinations(seat.hand)
+
+        val candidate =
+            if (currentCombination == null) {
+                chooseLeadCombination(allCombinations)
+            } else {
+                chooseResponseCombination(allCombinations, currentCombination)
+            }
+
+        return if (candidate == null) {
+            AiDecision.Pass
+        } else {
+            AiDecision.Play(candidate.cards.map { it.id }.toSet())
+        }
+    }
+
+    private fun chooseLeadCombination(combinations: List<PlayCombination>): PlayCombination? {
+        val openingCard = Card(suit = CardSuit.DIAMONDS, rank = CardRank.THREE)
+        val openingCandidates = combinations.filter { combination ->
+            combination.cards.any { it.id == openingCard.id }
+        }
+        val candidatePool = if (openingCandidates.isNotEmpty()) openingCandidates else combinations
+
+        return candidatePool
+            .filter { it.cardCount == 1 }
+            .minWithOrNull(compareBy<PlayCombination> { it.primaryRank }.thenBy { it.primarySuit })
+            ?: candidatePool.minWithOrNull(
+                compareBy<PlayCombination> { it.cardCount }
+                    .thenBy { it.type.typePower }
+                    .thenBy { it.primaryRank }
+                    .thenBy { it.primarySuit },
+            )
+    }
+
+    private fun chooseResponseCombination(
+        combinations: List<PlayCombination>,
+        currentCombination: PlayCombination,
+    ): PlayCombination? {
+        return combinations
+            .filter { evaluator.canBeat(it, currentCombination) }
+            .minWithOrNull(
+                compareBy<PlayCombination> { it.type.typePower }
+                    .thenBy { it.primaryRank }
+                    .thenBy { it.primarySuit },
+            )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/controller/client/GameActionMessageFormatter.kt
+++ b/app/src/main/java/com/example/chudadi/controller/client/GameActionMessageFormatter.kt
@@ -1,0 +1,17 @@
+package com.example.chudadi.controller.client
+
+import com.example.chudadi.model.game.engine.GameActionError
+
+object GameActionMessageFormatter {
+    fun format(error: GameActionError?): String? {
+        return when (error) {
+            GameActionError.MATCH_FINISHED -> "本局已经结束"
+            GameActionError.NOT_CURRENT_TURN -> "当前还没轮到你"
+            GameActionError.INVALID_PLAY_TYPE -> "牌型不合法"
+            GameActionError.OPENING_MOVE_MUST_CONTAIN_DIAMOND_THREE -> "首轮首手必须包含方块 3"
+            GameActionError.PLAY_DOES_NOT_BEAT_CURRENT -> "当前牌不够大"
+            GameActionError.CANNOT_PASS_LEAD_TURN -> "本轮领出者必须先出牌"
+            null -> null
+        }
+    }
+}

--- a/app/src/main/java/com/example/chudadi/controller/client/LocalPlayerController.kt
+++ b/app/src/main/java/com/example/chudadi/controller/client/LocalPlayerController.kt
@@ -1,0 +1,167 @@
+package com.example.chudadi.controller.client
+
+import com.example.chudadi.ai.rulebased.AiDecision
+import com.example.chudadi.ai.rulebased.RuleBasedAiPlayer
+import com.example.chudadi.controller.game.MatchUiStateMapper
+import com.example.chudadi.controller.server.LocalAuthoritativeController
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.snapshot.MatchUiState
+import com.example.chudadi.network.protocol.PassCommand
+import com.example.chudadi.network.protocol.PlayCardCommand
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class LocalPlayerController(
+    private val serverController: LocalAuthoritativeController,
+    private val aiPlayer: RuleBasedAiPlayer,
+    private val mapper: MatchUiStateMapper,
+    private val scope: CoroutineScope,
+) {
+    private val _uiState = MutableStateFlow(MatchUiState())
+    val uiState: StateFlow<MatchUiState> = _uiState.asStateFlow()
+
+    private var currentMatch: Match? = null
+    private var selectedCardIds: Set<String> = emptySet()
+    private var lastActionMessage: String? = null
+    private var aiTurnJob: Job? = null
+
+    fun onRequestStartLocalMatch() {
+        aiTurnJob?.cancel()
+        currentMatch = serverController.startLocalMatch()
+        selectedCardIds = emptySet()
+        lastActionMessage = null
+        pushUiState()
+        maybeResolveAiTurns()
+    }
+
+    fun onToggleCardSelection(cardId: String) {
+        if (!_uiState.value.isHumanTurn) {
+            return
+        }
+
+        selectedCardIds =
+            if (cardId in selectedCardIds) {
+                selectedCardIds - cardId
+            } else {
+                selectedCardIds + cardId
+            }
+        pushUiState()
+    }
+
+    fun onClearSelection() {
+        if (selectedCardIds.isEmpty()) {
+            return
+        }
+        selectedCardIds = emptySet()
+        pushUiState()
+    }
+
+    fun onRequestPlayCards() {
+        val match = currentMatch ?: return
+        val result = serverController.handleCommand(
+            match = match,
+            seatIndex = HUMAN_SEAT_ID,
+            command = PlayCardCommand(selectedCardIds),
+        )
+        currentMatch = result.match
+        lastActionMessage = result.message ?: GameActionMessageFormatter.format(result.error)
+        if (result.success) {
+            selectedCardIds = emptySet()
+        }
+        pushUiState()
+        if (result.success) {
+            maybeResolveAiTurns()
+        }
+    }
+
+    fun onRequestPass() {
+        val match = currentMatch ?: return
+        val result = serverController.handleCommand(
+            match = match,
+            seatIndex = HUMAN_SEAT_ID,
+            command = PassCommand,
+        )
+        currentMatch = result.match
+        lastActionMessage = result.message ?: GameActionMessageFormatter.format(result.error)
+        if (result.success) {
+            selectedCardIds = emptySet()
+        }
+        pushUiState()
+        if (result.success) {
+            maybeResolveAiTurns()
+        }
+    }
+
+    fun onRequestRestartMatch() {
+        onRequestStartLocalMatch()
+    }
+
+    fun onExitToHome() {
+        aiTurnJob?.cancel()
+        currentMatch = null
+        selectedCardIds = emptySet()
+        lastActionMessage = null
+        pushUiState()
+    }
+
+    fun dispose() {
+        aiTurnJob?.cancel()
+    }
+
+    private fun maybeResolveAiTurns() {
+        aiTurnJob?.cancel()
+        aiTurnJob =
+            scope.launch {
+                repeat(MAX_AI_CHAIN) {
+                    val match = currentMatch ?: return@launch
+                    if (match.phase == MatchPhase.FINISHED || match.activeSeatIndex == HUMAN_SEAT_ID) {
+                        return@launch
+                    }
+
+                    val decision = aiPlayer.decideAction(match, match.activeSeatIndex)
+                    val result =
+                        when (decision) {
+                            is AiDecision.Play ->
+                                serverController.handleCommand(
+                                    match = match,
+                                    seatIndex = match.activeSeatIndex,
+                                    command = PlayCardCommand(decision.cardIds),
+                                )
+
+                            AiDecision.Pass ->
+                                serverController.handleCommand(
+                                    match = match,
+                                    seatIndex = match.activeSeatIndex,
+                                    command = PassCommand,
+                                )
+                        }
+                    currentMatch = result.match
+                    lastActionMessage = result.message ?: GameActionMessageFormatter.format(result.error)
+                    selectedCardIds = emptySet()
+                    pushUiState()
+
+                    if (!result.success) {
+                        return@launch
+                    }
+                }
+            }
+    }
+
+    private fun pushUiState() {
+        _uiState.value = mapper.map(
+            match = currentMatch,
+            selectedCardIds = selectedCardIds,
+            lastActionMessage = lastActionMessage,
+        )
+    }
+
+    companion object {
+        private const val HUMAN_SEAT_ID = 0
+        private const val MAX_AI_CHAIN = 32
+    }
+}

--- a/app/src/main/java/com/example/chudadi/controller/game/LocalGameAction.kt
+++ b/app/src/main/java/com/example/chudadi/controller/game/LocalGameAction.kt
@@ -1,0 +1,14 @@
+package com.example.chudadi.controller.game
+
+sealed interface LocalGameAction {
+    data object StartLocalMatch : LocalGameAction
+    data class ToggleCardSelection(
+        val cardId: String,
+    ) : LocalGameAction
+
+    data object ClearSelection : LocalGameAction
+    data object SubmitSelectedCards : LocalGameAction
+    data object PassTurn : LocalGameAction
+    data object RestartMatch : LocalGameAction
+    data object ExitToHome : LocalGameAction
+}

--- a/app/src/main/java/com/example/chudadi/controller/game/LocalMatchViewModel.kt
+++ b/app/src/main/java/com/example/chudadi/controller/game/LocalMatchViewModel.kt
@@ -1,0 +1,56 @@
+package com.example.chudadi.controller.game
+
+import androidx.lifecycle.ViewModel
+import com.example.chudadi.ai.rulebased.AiDecision
+import com.example.chudadi.ai.rulebased.RuleBasedAiPlayer
+import com.example.chudadi.controller.client.LocalPlayerController
+import com.example.chudadi.controller.server.LocalAuthoritativeController
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.snapshot.MatchUiState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.StateFlow
+
+class LocalMatchViewModel(
+    private val engine: GameEngine,
+    private val aiPlayer: RuleBasedAiPlayer,
+    private val mapper: MatchUiStateMapper,
+) : ViewModel() {
+    constructor() : this(engine = GameEngine())
+
+    constructor(engine: GameEngine) : this(
+        engine = engine,
+        aiPlayer = RuleBasedAiPlayer(engine.evaluator()),
+        mapper = MatchUiStateMapper(engine),
+    )
+    private val viewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+    private val controller =
+        LocalPlayerController(
+            serverController = LocalAuthoritativeController(engine),
+            aiPlayer = aiPlayer,
+            mapper = mapper,
+            scope = viewModelScope,
+        )
+
+    val uiState: StateFlow<MatchUiState> = controller.uiState
+
+    fun dispatch(action: LocalGameAction) {
+        when (action) {
+            LocalGameAction.StartLocalMatch -> controller.onRequestStartLocalMatch()
+            LocalGameAction.ClearSelection -> controller.onClearSelection()
+            LocalGameAction.SubmitSelectedCards -> controller.onRequestPlayCards()
+            LocalGameAction.PassTurn -> controller.onRequestPass()
+            LocalGameAction.RestartMatch -> controller.onRequestRestartMatch()
+            LocalGameAction.ExitToHome -> controller.onExitToHome()
+            is LocalGameAction.ToggleCardSelection -> controller.onToggleCardSelection(action.cardId)
+        }
+    }
+
+    override fun onCleared() {
+        controller.dispose()
+        viewModelScope.coroutineContext.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/main/java/com/example/chudadi/controller/game/MatchUiStateMapper.kt
+++ b/app/src/main/java/com/example/chudadi/controller/game/MatchUiStateMapper.kt
@@ -1,0 +1,88 @@
+package com.example.chudadi.controller.game
+
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.SeatStatus
+import com.example.chudadi.model.game.snapshot.MatchUiState
+import com.example.chudadi.model.game.snapshot.OpponentSummary
+import com.example.chudadi.model.game.snapshot.ResultSummary
+import com.example.chudadi.model.game.snapshot.TablePlaySummary
+
+class MatchUiStateMapper(
+    private val engine: GameEngine,
+) {
+    fun map(
+        match: Match?,
+        selectedCardIds: Set<String>,
+        lastActionMessage: String?,
+    ): MatchUiState {
+        if (match == null) {
+            return MatchUiState()
+        }
+
+        val humanSeat = match.seats.first { it.seatId == HUMAN_SEAT_ID }
+        val selectedCards = humanSeat.hand.filter { it.id in selectedCardIds }.map(Card::id).toSet()
+        val tablePlays = match.trickState.tablePlays.entries
+            .sortedBy { it.key }
+            .map { (seatId, combination) ->
+                val owner = match.seats.first { it.seatId == seatId }
+                TablePlaySummary(
+                    ownerSeatId = owner.seatId,
+                    ownerName = owner.displayName,
+                    combinationLabel = combination.type.displayName,
+                    cardLabels = combination.cards.sortedWith(Card.gameComparator).map(Card::displayName),
+                )
+            }
+
+        return MatchUiState(
+            phase = match.phase,
+            playerHand = humanSeat.hand.sortedWith(Card.gameComparator),
+            selectedCards = selectedCards,
+            opponentSummaries = match.seats
+                .filterNot { it.seatId == HUMAN_SEAT_ID }
+                .map { seat ->
+                    OpponentSummary(
+                        seatId = seat.seatId,
+                        displayName = seat.displayName,
+                        remainingCards = seat.hand.size,
+                        isCurrentActor = seat.seatId == match.activeSeatIndex,
+                        hasPassed = seat.status == SeatStatus.PASSED,
+                    )
+                },
+            currentActorName = match.seats.first { it.seatId == match.activeSeatIndex }.displayName,
+            tablePlays = tablePlays,
+            currentTablePlay = match.trickState.currentCombination?.let { combination ->
+                val owner = match.seats.first { it.seatId == match.trickState.lastWinningSeatIndex }
+                TablePlaySummary(
+                    ownerSeatId = owner.seatId,
+                    ownerName = owner.displayName,
+                    combinationLabel = combination.type.displayName,
+                    cardLabels = combination.cards.sortedWith(Card.gameComparator).map(Card::displayName),
+                )
+            },
+            lastActionMessage = lastActionMessage,
+            canSubmitPlay = engine.canSubmitSelectedCards(
+                match = match,
+                seatIndex = HUMAN_SEAT_ID,
+                selectedCardIds = selectedCardIds,
+            ),
+            canPass = engine.canPass(
+                match = match,
+                seatIndex = HUMAN_SEAT_ID,
+            ),
+            resultSummary = match.result?.let { result ->
+                ResultSummary(
+                    winnerName = match.seats.first { it.seatId == result.winnerSeatIndex }.displayName,
+                    rankingLines = result.summaryLines,
+                )
+            },
+            isHumanTurn = match.phase != MatchPhase.FINISHED && match.activeSeatIndex == HUMAN_SEAT_ID,
+        )
+    }
+
+    companion object {
+        const val HUMAN_SEAT_ID = 0
+    }
+}

--- a/app/src/main/java/com/example/chudadi/controller/server/LocalAuthoritativeController.kt
+++ b/app/src/main/java/com/example/chudadi/controller/server/LocalAuthoritativeController.kt
@@ -1,0 +1,46 @@
+package com.example.chudadi.controller.server
+
+import com.example.chudadi.model.game.engine.ActionResult
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.network.protocol.GameCommand
+
+class LocalAuthoritativeController(
+    private val engine: GameEngine,
+) {
+    fun startLocalMatch(): Match = engine.startLocalMatch()
+
+    fun handleCommand(
+        match: Match,
+        seatIndex: Int,
+        command: GameCommand,
+    ): ActionResult {
+        return command.execute(
+            match = match,
+            seatIndex = seatIndex,
+            engine = engine,
+        )
+    }
+
+    fun canSubmitSelectedCards(
+        match: Match?,
+        seatIndex: Int,
+        selectedCardIds: Set<String>,
+    ): Boolean {
+        return engine.canSubmitSelectedCards(
+            match = match,
+            seatIndex = seatIndex,
+            selectedCardIds = selectedCardIds,
+        )
+    }
+
+    fun canPass(
+        match: Match?,
+        seatIndex: Int,
+    ): Boolean {
+        return engine.canPass(
+            match = match,
+            seatIndex = seatIndex,
+        )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/model/game/engine/GameActionError.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/engine/GameActionError.kt
@@ -1,0 +1,10 @@
+package com.example.chudadi.model.game.engine
+
+enum class GameActionError {
+    MATCH_FINISHED,
+    NOT_CURRENT_TURN,
+    INVALID_PLAY_TYPE,
+    OPENING_MOVE_MUST_CONTAIN_DIAMOND_THREE,
+    PLAY_DOES_NOT_BEAT_CURRENT,
+    CANNOT_PASS_LEAD_TURN,
+}

--- a/app/src/main/java/com/example/chudadi/model/game/engine/GameEngine.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/engine/GameEngine.kt
@@ -1,0 +1,213 @@
+@file:Suppress("ReturnCount")
+
+package com.example.chudadi.model.game.engine
+
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.Seat
+import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.entity.SeatStatus
+import com.example.chudadi.model.game.entity.TrickState
+import com.example.chudadi.model.game.rule.CombinationEvaluator
+import java.util.UUID
+import kotlin.random.Random
+
+data class ActionResult(
+    val match: Match,
+    val success: Boolean,
+    val message: String? = null,
+    val error: GameActionError? = null,
+)
+
+open class GameEngine(
+    private val random: Random = Random.Default,
+    private val evaluator: CombinationEvaluator = CombinationEvaluator(),
+) {
+    open fun startLocalMatch(): Match {
+        val shuffledDeck = Card.standardDeck().shuffled(random)
+        val seats = listOf(
+            createSeat(0, "You", SeatControllerType.HUMAN, shuffledDeck.subList(0, 13)),
+            createSeat(1, "AI 1", SeatControllerType.RULE_BASED_AI, shuffledDeck.subList(13, 26)),
+            createSeat(2, "AI 2", SeatControllerType.RULE_BASED_AI, shuffledDeck.subList(26, 39)),
+            createSeat(3, "AI 3", SeatControllerType.RULE_BASED_AI, shuffledDeck.subList(39, 52)),
+        )
+
+        val openingCard = Card(suit = CardSuit.DIAMONDS, rank = CardRank.THREE)
+        val openingSeat = seats.first { seat -> seat.hand.any { it.id == openingCard.id } }
+
+        return Match(
+            matchId = UUID.randomUUID().toString(),
+            phase = MatchPhase.PLAYER_TURN,
+            seats = seats,
+            activeSeatIndex = openingSeat.seatId,
+            trickState = TrickState(
+                leadSeatIndex = openingSeat.seatId,
+                lastWinningSeatIndex = openingSeat.seatId,
+                currentCombination = null,
+                passCount = 0,
+                roundNumber = 1,
+            ),
+            playHistory = listOf("${openingSeat.displayName} leads the first round"),
+            result = null,
+        )
+    }
+
+    open fun submitSelectedCards(
+        match: Match,
+        seatIndex: Int,
+        selectedCardIds: Set<String>,
+    ): ActionResult {
+        if (match.phase == MatchPhase.FINISHED) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.MATCH_FINISHED,
+            )
+        }
+        if (match.activeSeatIndex != seatIndex) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.NOT_CURRENT_TURN,
+            )
+        }
+
+        val seat = match.seats.first { it.seatId == seatIndex }
+        val selectedCards = seat.hand.filter { it.id in selectedCardIds }
+        val candidate = evaluator.parse(selectedCards)
+            ?: return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.INVALID_PLAY_TYPE,
+            )
+
+        if (requiresOpeningThree(match, seatIndex) && candidate.cards.none { it.id == OPENING_CARD.id }) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.OPENING_MOVE_MUST_CONTAIN_DIAMOND_THREE,
+            )
+        }
+
+        if (!evaluator.canBeat(candidate, match.trickState.currentCombination)) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.PLAY_DOES_NOT_BEAT_CURRENT,
+            )
+        }
+
+        val updatedMatch = TurnResolver.applyPlay(
+            match = match,
+            seatIndex = seatIndex,
+            combination = candidate,
+        )
+        val message = if (updatedMatch.phase == MatchPhase.FINISHED) {
+            "${seat.displayName} wins the match."
+        } else {
+            "${seat.displayName} played ${candidate.displayName}"
+        }
+        return ActionResult(match = updatedMatch, success = true, message = message)
+    }
+
+    open fun passTurn(
+        match: Match,
+        seatIndex: Int,
+    ): ActionResult {
+        if (match.phase == MatchPhase.FINISHED) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.MATCH_FINISHED,
+            )
+        }
+        if (match.activeSeatIndex != seatIndex) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.NOT_CURRENT_TURN,
+            )
+        }
+        if (!canPass(match, seatIndex)) {
+            return ActionResult(
+                match = match,
+                success = false,
+                error = GameActionError.CANNOT_PASS_LEAD_TURN,
+            )
+        }
+
+        val seat = match.seats.first { it.seatId == seatIndex }
+        return ActionResult(
+            match = TurnResolver.applyPass(match, seatIndex),
+            success = true,
+            message = "${seat.displayName} 要不起",
+        )
+    }
+
+    open fun canSubmitSelectedCards(
+        match: Match?,
+        seatIndex: Int,
+        selectedCardIds: Set<String>,
+    ): Boolean {
+        val activeMatch = match ?: return false
+        if (activeMatch.phase == MatchPhase.FINISHED || activeMatch.activeSeatIndex != seatIndex) {
+            return false
+        }
+        val seat = activeMatch.seats.first { it.seatId == seatIndex }
+        val selectedCards = seat.hand.filter { it.id in selectedCardIds }
+        val candidate = evaluator.parse(selectedCards) ?: return false
+        if (requiresOpeningThree(activeMatch, seatIndex) && candidate.cards.none { it.id == OPENING_CARD.id }) {
+            return false
+        }
+        return evaluator.canBeat(candidate, activeMatch.trickState.currentCombination)
+    }
+
+    open fun canPass(
+        match: Match?,
+        seatIndex: Int,
+    ): Boolean {
+        val activeMatch = match ?: return false
+        if (activeMatch.phase == MatchPhase.FINISHED || activeMatch.activeSeatIndex != seatIndex) {
+            return false
+        }
+        return activeMatch.trickState.currentCombination != null
+    }
+
+    open fun evaluator(): CombinationEvaluator = evaluator
+
+    private fun createSeat(
+        seatId: Int,
+        displayName: String,
+        controllerType: SeatControllerType,
+        cards: List<Card>,
+    ): Seat {
+        return Seat(
+            seatId = seatId,
+            displayName = displayName,
+            controllerType = controllerType,
+            hand = cards.sortedWith(Card.gameComparator),
+            status = SeatStatus.ACTIVE,
+        )
+    }
+
+    private fun requiresOpeningThree(
+        match: Match,
+        seatIndex: Int,
+    ): Boolean {
+        return match.trickState.currentCombination == null &&
+            match.trickState.roundNumber == 1 &&
+            match.trickState.passCount == 0 &&
+            match.trickState.leadSeatIndex == seatIndex &&
+            match.trickState.lastWinningSeatIndex == seatIndex
+    }
+
+    companion object {
+        private val OPENING_CARD = Card(
+            suit = CardSuit.DIAMONDS,
+            rank = CardRank.THREE,
+        )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/model/game/engine/TurnResolver.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/engine/TurnResolver.kt
@@ -1,0 +1,165 @@
+package com.example.chudadi.model.game.engine
+
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.PlayCombination
+import com.example.chudadi.model.game.entity.RoundResult
+import com.example.chudadi.model.game.entity.Seat
+import com.example.chudadi.model.game.entity.SeatStatus
+
+object TurnResolver {
+    fun applyPlay(
+        match: Match,
+        seatIndex: Int,
+        combination: PlayCombination,
+    ): Match {
+        val currentSeat = match.seats.first { it.seatId == seatIndex }
+        val remainingHand = currentSeat.hand.filterNot { card ->
+            combination.cards.any { selected -> selected.id == card.id }
+        }
+
+        val updatedSeats = match.seats.map { seat ->
+            when {
+                seat.seatId == currentSeat.seatId -> {
+                    seat.copy(
+                        hand = remainingHand,
+                        status = if (remainingHand.isEmpty()) SeatStatus.FINISHED else SeatStatus.ACTIVE,
+                    )
+                }
+
+                seat.status != SeatStatus.FINISHED -> seat.copy(status = SeatStatus.ACTIVE)
+                else -> seat
+            }
+        }
+
+        if (remainingHand.isEmpty()) {
+            val rankedSeats = assignFinishOrder(updatedSeats, winnerSeatId = seatIndex)
+            return match.copy(
+                phase = MatchPhase.FINISHED,
+                seats = rankedSeats,
+                trickState = match.trickState.copy(
+                    leadSeatIndex = seatIndex,
+                    lastWinningSeatIndex = seatIndex,
+                    currentCombination = combination,
+                    passCount = 0,
+                    tablePlays = match.trickState.tablePlays + (seatIndex to combination),
+                ),
+                playHistory = match.playHistory + "${currentSeat.displayName} played ${combination.displayName}",
+                result = createResult(rankedSeats),
+            )
+        }
+
+        return match.copy(
+            phase = MatchPhase.PLAYER_TURN,
+            seats = updatedSeats,
+            activeSeatIndex = nextActiveSeatIndex(updatedSeats, seatIndex),
+            trickState = match.trickState.copy(
+                leadSeatIndex = seatIndex,
+                lastWinningSeatIndex = seatIndex,
+                currentCombination = combination,
+                passCount = 0,
+                tablePlays = match.trickState.tablePlays + (seatIndex to combination),
+            ),
+            playHistory = match.playHistory + "${currentSeat.displayName} played ${combination.displayName}",
+        )
+    }
+
+    fun applyPass(
+        match: Match,
+        seatIndex: Int,
+    ): Match {
+        val currentSeat = match.seats.first { it.seatId == seatIndex }
+        val updatedSeats = match.seats.map { seat ->
+            if (seat.seatId == seatIndex) {
+                seat.copy(status = SeatStatus.PASSED)
+            } else {
+                seat
+            }
+        }
+
+        val unfinishedSeats = updatedSeats.filter { it.status != SeatStatus.FINISHED }
+        val nextPassCount = match.trickState.passCount + 1
+        val shouldResetRound = nextPassCount >= unfinishedSeats.size - 1
+        val tablePlaysAfterPass = match.trickState.tablePlays - seatIndex
+
+        return if (shouldResetRound) {
+            val resetSeats = updatedSeats.map { seat ->
+                if (seat.status != SeatStatus.FINISHED) {
+                    seat.copy(status = SeatStatus.ACTIVE)
+                } else {
+                    seat
+                }
+            }
+            match.copy(
+                phase = MatchPhase.ROUND_RESET,
+                seats = resetSeats,
+                activeSeatIndex = match.trickState.lastWinningSeatIndex,
+                trickState = match.trickState.copy(
+                    leadSeatIndex = match.trickState.lastWinningSeatIndex,
+                    currentCombination = null,
+                    passCount = 0,
+                    roundNumber = match.trickState.roundNumber + 1,
+                    tablePlays = emptyMap(),
+                ),
+                playHistory = match.playHistory + "${currentSeat.displayName} passed",
+            )
+        } else {
+            match.copy(
+                phase = MatchPhase.PLAYER_TURN,
+                seats = updatedSeats,
+                activeSeatIndex = nextActiveSeatIndex(updatedSeats, seatIndex),
+                trickState = match.trickState.copy(
+                    passCount = nextPassCount,
+                    tablePlays = tablePlaysAfterPass,
+                ),
+                playHistory = match.playHistory + "${currentSeat.displayName} passed",
+            )
+        }
+    }
+
+    private fun nextActiveSeatIndex(
+        seats: List<Seat>,
+        fromSeatId: Int,
+    ): Int {
+        val maxIndex = seats.maxOf { it.seatId }
+        var cursor = fromSeatId
+        repeat(maxIndex + 1) {
+            cursor = (cursor + 1) % (maxIndex + 1)
+            val nextSeat = seats.first { it.seatId == cursor }
+            if (nextSeat.status != SeatStatus.FINISHED) {
+                return cursor
+            }
+        }
+        return fromSeatId
+    }
+
+    private fun assignFinishOrder(
+        seats: List<Seat>,
+        winnerSeatId: Int,
+    ): List<Seat> {
+        val winner = seats.first { it.seatId == winnerSeatId }
+        val others = seats
+            .filterNot { it.seatId == winnerSeatId }
+            .sortedWith(compareBy<Seat> { it.hand.size }.thenBy { it.seatId })
+
+        val ranking = listOf(winner) + others
+        return seats.map { seat ->
+            val position = ranking.indexOfFirst { it.seatId == seat.seatId }
+            seat.copy(
+                status = if (seat.seatId == winnerSeatId) SeatStatus.FINISHED else seat.status,
+                finishOrder = position + 1,
+            )
+        }
+    }
+
+    private fun createResult(seats: List<Seat>): RoundResult {
+        val orderedSeats = seats.sortedBy { it.finishOrder ?: Int.MAX_VALUE }
+        return RoundResult(
+            winnerSeatIndex = orderedSeats.first().seatId,
+            ranking = orderedSeats.map(Seat::seatId),
+            summaryLines = orderedSeats.mapIndexed { index, seat ->
+                "${index + 1}. ${seat.displayName} (${seat.hand.size} cards left)"
+            },
+        )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/model/game/entity/Card.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/Card.kt
@@ -1,0 +1,52 @@
+package com.example.chudadi.model.game.entity
+
+enum class CardSuit(
+    val symbol: String,
+    val sortOrder: Int,
+) {
+    DIAMONDS(symbol = "\u2666", sortOrder = 0),
+    CLUBS(symbol = "\u2663", sortOrder = 1),
+    HEARTS(symbol = "\u2665", sortOrder = 2),
+    SPADES(symbol = "\u2660", sortOrder = 3),
+}
+
+enum class CardRank(
+    val displayName: String,
+    val strength: Int,
+) {
+    THREE(displayName = "3", strength = 0),
+    FOUR(displayName = "4", strength = 1),
+    FIVE(displayName = "5", strength = 2),
+    SIX(displayName = "6", strength = 3),
+    SEVEN(displayName = "7", strength = 4),
+    EIGHT(displayName = "8", strength = 5),
+    NINE(displayName = "9", strength = 6),
+    TEN(displayName = "10", strength = 7),
+    JACK(displayName = "J", strength = 8),
+    QUEEN(displayName = "Q", strength = 9),
+    KING(displayName = "K", strength = 10),
+    ACE(displayName = "A", strength = 11),
+    TWO(displayName = "2", strength = 12),
+}
+
+data class Card(
+    val suit: CardSuit,
+    val rank: CardRank,
+) {
+    val id: String = "${rank.name}_${suit.name}"
+    val displayName: String = "${rank.displayName}${suit.symbol}"
+
+    companion object {
+        fun standardDeck(): List<Card> {
+            return CardSuit.entries.flatMap { suit ->
+                CardRank.entries.map { rank ->
+                    Card(suit = suit, rank = rank)
+                }
+            }
+        }
+
+        val gameComparator: Comparator<Card> =
+            compareBy<Card> { it.rank.strength }
+                .thenBy { it.suit.sortOrder }
+    }
+}

--- a/app/src/main/java/com/example/chudadi/model/game/entity/Match.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/Match.kt
@@ -1,0 +1,11 @@
+package com.example.chudadi.model.game.entity
+
+data class Match(
+    val matchId: String,
+    val phase: MatchPhase,
+    val seats: List<Seat>,
+    val activeSeatIndex: Int,
+    val trickState: TrickState,
+    val playHistory: List<String>,
+    val result: RoundResult?,
+)

--- a/app/src/main/java/com/example/chudadi/model/game/entity/MatchPhase.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/MatchPhase.kt
@@ -1,0 +1,9 @@
+package com.example.chudadi.model.game.entity
+
+enum class MatchPhase {
+    NOT_STARTED,
+    DEALING,
+    PLAYER_TURN,
+    ROUND_RESET,
+    FINISHED,
+}

--- a/app/src/main/java/com/example/chudadi/model/game/entity/PlayCombination.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/PlayCombination.kt
@@ -1,0 +1,18 @@
+package com.example.chudadi.model.game.entity
+
+import com.example.chudadi.model.game.rule.CombinationType
+
+data class PlayCombination(
+    val type: CombinationType,
+    val cards: List<Card>,
+    val primaryRank: Int,
+    val primarySuit: Int,
+    val rankVector: List<Int> = emptyList(),
+) {
+    val cardCount: Int = cards.size
+    val displayName: String = buildString {
+        append(type.displayName)
+        append(": ")
+        append(cards.sortedWith(Card.gameComparator).joinToString(" ") { it.displayName })
+    }
+}

--- a/app/src/main/java/com/example/chudadi/model/game/entity/RoundResult.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/RoundResult.kt
@@ -1,0 +1,7 @@
+package com.example.chudadi.model.game.entity
+
+data class RoundResult(
+    val winnerSeatIndex: Int,
+    val ranking: List<Int>,
+    val summaryLines: List<String>,
+)

--- a/app/src/main/java/com/example/chudadi/model/game/entity/Seat.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/Seat.kt
@@ -1,0 +1,21 @@
+package com.example.chudadi.model.game.entity
+
+enum class SeatControllerType {
+    HUMAN,
+    RULE_BASED_AI,
+}
+
+enum class SeatStatus {
+    ACTIVE,
+    PASSED,
+    FINISHED,
+}
+
+data class Seat(
+    val seatId: Int,
+    val displayName: String,
+    val controllerType: SeatControllerType,
+    val hand: List<Card>,
+    val status: SeatStatus = SeatStatus.ACTIVE,
+    val finishOrder: Int? = null,
+)

--- a/app/src/main/java/com/example/chudadi/model/game/entity/TrickState.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/entity/TrickState.kt
@@ -1,0 +1,10 @@
+package com.example.chudadi.model.game.entity
+
+data class TrickState(
+    val leadSeatIndex: Int,
+    val lastWinningSeatIndex: Int,
+    val currentCombination: PlayCombination?,
+    val passCount: Int,
+    val roundNumber: Int,
+    val tablePlays: Map<Int, PlayCombination> = emptyMap(),
+)

--- a/app/src/main/java/com/example/chudadi/model/game/rule/CombinationEvaluator.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/rule/CombinationEvaluator.kt
@@ -1,0 +1,235 @@
+@file:Suppress("ReturnCount")
+
+package com.example.chudadi.model.game.rule
+
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.PlayCombination
+
+class CombinationEvaluator {
+    fun parse(cards: List<Card>): PlayCombination? {
+        if (cards.isEmpty()) {
+            return null
+        }
+
+        val sortedCards = cards.distinctBy(Card::id).sortedWith(Card.gameComparator)
+        if (sortedCards.size != cards.size) {
+            return null
+        }
+
+        return when (sortedCards.size) {
+            1 -> buildSingle(sortedCards)
+            2 -> buildPair(sortedCards)
+            3 -> buildTriple(sortedCards)
+            5 -> buildFiveCardCombination(sortedCards)
+            else -> null
+        }
+    }
+
+    fun canBeat(
+        candidate: PlayCombination,
+        current: PlayCombination?,
+    ): Boolean {
+        if (current == null) {
+            return true
+        }
+
+        if (candidate.cardCount != current.cardCount) {
+            return false
+        }
+
+        if (candidate.cardCount == 5 && candidate.type.typePower != current.type.typePower) {
+            return candidate.type.typePower > current.type.typePower
+        }
+
+        if (candidate.type != current.type) {
+            return false
+        }
+
+        return compareSameType(candidate, current) > 0
+    }
+
+    fun generateAllValidCombinations(cards: List<Card>): List<PlayCombination> {
+        val combinations = mutableListOf<PlayCombination>()
+        val sortedCards = cards.sortedWith(Card.gameComparator)
+
+        combinations += sortedCards.mapNotNull { parse(listOf(it)) }
+        combinations += sortedCards.combinations(2).mapNotNull(::parse)
+        combinations += sortedCards.combinations(3).mapNotNull(::parse)
+        combinations += sortedCards.combinations(5).mapNotNull(::parse)
+
+        return combinations
+            .distinctBy { combination ->
+                combination.type to combination.cards.map(Card::id).sorted()
+            }
+            .sortedWith { left, right ->
+                when {
+                    left.cardCount != right.cardCount -> left.cardCount.compareTo(right.cardCount)
+                    left.cardCount == 5 && left.type.typePower != right.type.typePower ->
+                        left.type.typePower.compareTo(right.type.typePower)
+                    else -> compareSameType(left, right)
+                }
+            }
+    }
+
+    private fun buildSingle(cards: List<Card>): PlayCombination {
+        val card = cards.single()
+        return PlayCombination(
+            type = CombinationType.SINGLE,
+            cards = cards,
+            primaryRank = card.rank.strength,
+            primarySuit = card.suit.sortOrder,
+        )
+    }
+
+    private fun buildPair(cards: List<Card>): PlayCombination? {
+        if (cards.map { it.rank }.distinct().size != 1) {
+            return null
+        }
+
+        return PlayCombination(
+            type = CombinationType.PAIR,
+            cards = cards,
+            primaryRank = cards.first().rank.strength,
+            primarySuit = cards.maxOf { it.suit.sortOrder },
+        )
+    }
+
+    private fun buildTriple(cards: List<Card>): PlayCombination? {
+        if (cards.map { it.rank }.distinct().size != 1) {
+            return null
+        }
+
+        return PlayCombination(
+            type = CombinationType.TRIPLE,
+            cards = cards,
+            primaryRank = cards.first().rank.strength,
+            primarySuit = cards.maxOf { it.suit.sortOrder },
+        )
+    }
+
+    private fun buildFiveCardCombination(cards: List<Card>): PlayCombination? {
+        val rankGroups = cards.groupBy { it.rank }
+        val isFlush = cards.map { it.suit }.distinct().size == 1
+        val straightHighCard = getStraightHighCard(cards)
+
+        if (isFlush && straightHighCard != null) {
+            return PlayCombination(
+                type = CombinationType.STRAIGHT_FLUSH,
+                cards = cards,
+                primaryRank = straightHighCard.rank.strength,
+                primarySuit = straightHighCard.suit.sortOrder,
+            )
+        }
+
+        if (rankGroups.size == 2 && rankGroups.any { it.value.size == 4 }) {
+            val fourRank = rankGroups.entries.first { it.value.size == 4 }.key
+            val fourCards = rankGroups.getValue(fourRank)
+            return PlayCombination(
+                type = CombinationType.FOUR_WITH_ONE,
+                cards = cards,
+                primaryRank = fourRank.strength,
+                primarySuit = fourCards.maxOf { it.suit.sortOrder },
+            )
+        }
+
+        if (rankGroups.size == 2 && rankGroups.any { it.value.size == 3 }) {
+            val tripleRank = rankGroups.entries.first { it.value.size == 3 }.key
+            val tripleCards = rankGroups.getValue(tripleRank)
+            return PlayCombination(
+                type = CombinationType.FULL_HOUSE,
+                cards = cards,
+                primaryRank = tripleRank.strength,
+                primarySuit = tripleCards.maxOf { it.suit.sortOrder },
+            )
+        }
+
+        if (isFlush) {
+            return PlayCombination(
+                type = CombinationType.FLUSH,
+                cards = cards,
+                primaryRank = cards.maxOf { it.rank.strength },
+                primarySuit = cards.maxOf { it.suit.sortOrder },
+                rankVector = cards.sortedByDescending { it.rank.strength }.map { it.rank.strength },
+            )
+        }
+
+        if (straightHighCard != null) {
+            return PlayCombination(
+                type = CombinationType.STRAIGHT,
+                cards = cards,
+                primaryRank = straightHighCard.rank.strength,
+                primarySuit = straightHighCard.suit.sortOrder,
+            )
+        }
+
+        return null
+    }
+
+    private fun getStraightHighCard(cards: List<Card>): Card? {
+        if (cards.map { it.rank }.distinct().size != cards.size) {
+            return null
+        }
+        if (cards.any { it.rank == CardRank.TWO }) {
+            return null
+        }
+
+        val sortedCards = cards.sortedBy { it.rank.strength }
+        val isStraight = sortedCards
+            .zipWithNext()
+            .all { (left, right) -> right.rank.strength - left.rank.strength == 1 }
+
+        return if (isStraight) sortedCards.last() else null
+    }
+
+    private fun compareSameType(
+        left: PlayCombination,
+        right: PlayCombination,
+    ): Int {
+        val primaryRankComparison = left.primaryRank.compareTo(right.primaryRank)
+        if (primaryRankComparison != 0) {
+            return primaryRankComparison
+        }
+
+        if (left.type == CombinationType.FLUSH) {
+            left.rankVector.zip(right.rankVector).forEach { (leftRank, rightRank) ->
+                val comparison = leftRank.compareTo(rightRank)
+                if (comparison != 0) {
+                    return comparison
+                }
+            }
+        }
+
+        return left.primarySuit.compareTo(right.primarySuit)
+    }
+}
+
+private fun <T> List<T>.combinations(size: Int): List<List<T>> {
+    if (size == 0) {
+        return listOf(emptyList())
+    }
+    if (size > this.size) {
+        return emptyList()
+    }
+
+    val combinations = mutableListOf<List<T>>()
+
+    fun backtrack(
+        startIndex: Int,
+        current: MutableList<T>,
+    ) {
+        if (current.size == size) {
+            combinations += current.toList()
+            return
+        }
+
+        for (index in startIndex until this.size) {
+            current += this[index]
+            backtrack(index + 1, current)
+            current.removeAt(current.lastIndex)
+        }
+    }
+
+    backtrack(startIndex = 0, current = mutableListOf())
+    return combinations
+}

--- a/app/src/main/java/com/example/chudadi/model/game/rule/CombinationType.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/rule/CombinationType.kt
@@ -1,0 +1,16 @@
+package com.example.chudadi.model.game.rule
+
+enum class CombinationType(
+    val displayName: String,
+    val cardCount: Int,
+    val typePower: Int,
+) {
+    SINGLE(displayName = "Single", cardCount = 1, typePower = 0),
+    PAIR(displayName = "Pair", cardCount = 2, typePower = 0),
+    TRIPLE(displayName = "Triple", cardCount = 3, typePower = 0),
+    STRAIGHT(displayName = "Straight", cardCount = 5, typePower = 1),
+    FLUSH(displayName = "Flush", cardCount = 5, typePower = 2),
+    FULL_HOUSE(displayName = "Full House", cardCount = 5, typePower = 3),
+    FOUR_WITH_ONE(displayName = "Four with One", cardCount = 5, typePower = 4),
+    STRAIGHT_FLUSH(displayName = "Straight Flush", cardCount = 5, typePower = 5),
+}

--- a/app/src/main/java/com/example/chudadi/model/game/snapshot/MatchUiState.kt
+++ b/app/src/main/java/com/example/chudadi/model/game/snapshot/MatchUiState.kt
@@ -1,0 +1,39 @@
+package com.example.chudadi.model.game.snapshot
+
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.MatchPhase
+
+data class OpponentSummary(
+    val seatId: Int,
+    val displayName: String,
+    val remainingCards: Int,
+    val isCurrentActor: Boolean,
+    val hasPassed: Boolean,
+)
+
+data class TablePlaySummary(
+    val ownerSeatId: Int,
+    val ownerName: String,
+    val combinationLabel: String,
+    val cardLabels: List<String>,
+)
+
+data class ResultSummary(
+    val winnerName: String,
+    val rankingLines: List<String>,
+)
+
+data class MatchUiState(
+    val phase: MatchPhase = MatchPhase.NOT_STARTED,
+    val playerHand: List<Card> = emptyList(),
+    val selectedCards: Set<String> = emptySet(),
+    val opponentSummaries: List<OpponentSummary> = emptyList(),
+    val currentActorName: String = "",
+    val tablePlays: List<TablePlaySummary> = emptyList(),
+    val currentTablePlay: TablePlaySummary? = null,
+    val lastActionMessage: String? = null,
+    val canSubmitPlay: Boolean = false,
+    val canPass: Boolean = false,
+    val resultSummary: ResultSummary? = null,
+    val isHumanTurn: Boolean = false,
+)

--- a/app/src/main/java/com/example/chudadi/navigation/ChuDaDiNavGraph.kt
+++ b/app/src/main/java/com/example/chudadi/navigation/ChuDaDiNavGraph.kt
@@ -1,0 +1,112 @@
+package com.example.chudadi.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.chudadi.controller.game.LocalGameAction
+import com.example.chudadi.controller.game.LocalMatchViewModel
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.ui.game.GameScreenActions
+import com.example.chudadi.ui.game.GameScreen
+import com.example.chudadi.ui.home.HomeScreen
+import com.example.chudadi.ui.result.ResultScreen
+
+private const val HOME_ROUTE = "home"
+private const val GAME_ROUTE = "game"
+private const val RESULT_ROUTE = "result"
+
+@Composable
+fun ChuDaDiNavGraph(
+    viewModel: LocalMatchViewModel = viewModel(),
+) {
+    val navController = rememberNavController()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle().value
+
+    HandlePhaseNavigation(navController = navController, phase = uiState.phase)
+
+    NavHost(
+        navController = navController,
+        startDestination = HOME_ROUTE,
+    ) {
+        composable(HOME_ROUTE) {
+            HomeScreen(
+                onStartLocalMatch = {
+                    viewModel.dispatch(LocalGameAction.StartLocalMatch)
+                },
+            )
+        }
+        composable(GAME_ROUTE) {
+            GameScreen(
+                uiState = uiState,
+                actions =
+                    GameScreenActions(
+                        onToggleCardSelection = { cardId ->
+                            viewModel.dispatch(LocalGameAction.ToggleCardSelection(cardId))
+                        },
+                        onClearSelection = {
+                            viewModel.dispatch(LocalGameAction.ClearSelection)
+                        },
+                        onSubmitSelectedCards = {
+                            viewModel.dispatch(LocalGameAction.SubmitSelectedCards)
+                        },
+                        onPassTurn = {
+                            viewModel.dispatch(LocalGameAction.PassTurn)
+                        },
+                    ),
+            )
+        }
+        composable(RESULT_ROUTE) {
+            ResultScreen(
+                uiState = uiState,
+                onRestartMatch = {
+                    viewModel.dispatch(LocalGameAction.RestartMatch)
+                },
+                onExitToHome = {
+                    viewModel.dispatch(LocalGameAction.ExitToHome)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun HandlePhaseNavigation(
+    navController: NavHostController,
+    phase: MatchPhase,
+) {
+    LaunchedEffect(phase) {
+        when (phase) {
+            MatchPhase.NOT_STARTED -> {
+                if (navController.currentDestination?.route != HOME_ROUTE) {
+                    navController.navigate(HOME_ROUTE) {
+                        popUpTo(navController.graph.startDestinationId) {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                }
+            }
+
+            MatchPhase.FINISHED -> {
+                if (navController.currentDestination?.route != RESULT_ROUTE) {
+                    navController.navigate(RESULT_ROUTE) {
+                        launchSingleTop = true
+                    }
+                }
+            }
+
+            else -> {
+                if (navController.currentDestination?.route != GAME_ROUTE) {
+                    navController.navigate(GAME_ROUTE) {
+                        launchSingleTop = true
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/chudadi/network/protocol/GameCommand.kt
+++ b/app/src/main/java/com/example/chudadi/network/protocol/GameCommand.kt
@@ -1,0 +1,13 @@
+package com.example.chudadi.network.protocol
+
+import com.example.chudadi.model.game.engine.ActionResult
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Match
+
+interface GameCommand {
+    fun execute(
+        match: Match,
+        seatIndex: Int,
+        engine: GameEngine,
+    ): ActionResult
+}

--- a/app/src/main/java/com/example/chudadi/network/protocol/PassCommand.kt
+++ b/app/src/main/java/com/example/chudadi/network/protocol/PassCommand.kt
@@ -1,0 +1,18 @@
+package com.example.chudadi.network.protocol
+
+import com.example.chudadi.model.game.engine.ActionResult
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Match
+
+data object PassCommand : GameCommand {
+    override fun execute(
+        match: Match,
+        seatIndex: Int,
+        engine: GameEngine,
+    ): ActionResult {
+        return engine.passTurn(
+            match = match,
+            seatIndex = seatIndex,
+        )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/network/protocol/PlayCardCommand.kt
+++ b/app/src/main/java/com/example/chudadi/network/protocol/PlayCardCommand.kt
@@ -1,0 +1,21 @@
+package com.example.chudadi.network.protocol
+
+import com.example.chudadi.model.game.engine.ActionResult
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Match
+
+data class PlayCardCommand(
+    val selectedCardIds: Set<String>,
+) : GameCommand {
+    override fun execute(
+        match: Match,
+        seatIndex: Int,
+        engine: GameEngine,
+    ): ActionResult {
+        return engine.submitSelectedCards(
+            match = match,
+            seatIndex = seatIndex,
+            selectedCardIds = selectedCardIds,
+        )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/ui/ComposeTestTags.kt
+++ b/app/src/main/java/com/example/chudadi/ui/ComposeTestTags.kt
@@ -1,0 +1,15 @@
+package com.example.chudadi.ui
+
+object ComposeTestTags {
+    const val HOME_SCREEN = "home_screen"
+    const val START_MATCH_BUTTON = "start_match_button"
+    const val GAME_SCREEN = "game_screen"
+    const val ACTION_MESSAGE = "action_message"
+    const val CLEAR_SELECTION_BUTTON = "clear_selection_button"
+    const val PASS_BUTTON = "pass_button"
+    const val SUBMIT_BUTTON = "submit_button"
+    const val PLAYER_CARD_PREFIX = "player_card_"
+    const val RESULT_SCREEN = "result_screen"
+    const val RESTART_BUTTON = "restart_button"
+    const val EXIT_BUTTON = "exit_button"
+}

--- a/app/src/main/java/com/example/chudadi/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/example/chudadi/ui/game/GameScreen.kt
@@ -1,0 +1,531 @@
+@file:Suppress("TooManyFunctions")
+
+package com.example.chudadi.ui.game
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.example.chudadi.R
+import com.example.chudadi.model.game.entity.Card as GameCard
+import com.example.chudadi.model.game.snapshot.MatchUiState
+import com.example.chudadi.model.game.snapshot.OpponentSummary
+import com.example.chudadi.model.game.snapshot.TablePlaySummary
+import com.example.chudadi.ui.ComposeTestTags
+
+private val TableFelt = Color(0xFF163726)
+private val TableBorder = Color(0xFF8D6A33)
+private val WoodTint = Color(0xFF2A1B15)
+private val SeatPanel = Color(0xFF2F201A)
+private val SeatPanelBorder = Color(0xFF8C6A43)
+private val CardFace = Color(0xFFF5EEDB)
+private val CardStroke = Color(0xFFD9C9A6)
+private val CardBack = Color(0xFF7D4B32)
+private val CardRed = Color(0xFFB42318)
+private val CardBlack = Color(0xFF2C1C13)
+private const val LEFT_SEAT_ID = 1
+private const val TOP_SEAT_ID = 2
+private const val RIGHT_SEAT_ID = 3
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GameScreen(
+    uiState: MatchUiState,
+    actions: GameScreenActions,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(ComposeTestTags.GAME_SCREEN),
+        bottomBar = {
+            BottomActionBar(
+                uiState = uiState,
+                actions = actions,
+            )
+        },
+    ) { innerPadding ->
+        BoxWithConstraints(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(WoodTint)
+                .padding(innerPadding)
+                .padding(start = 12.dp, top = 6.dp, end = 12.dp, bottom = 0.dp),
+        ) {
+            val tableHeight =
+                when {
+                    maxHeight < 420.dp -> 220.dp
+                    maxHeight < 560.dp -> 280.dp
+                    maxHeight < 680.dp -> 320.dp
+                    maxHeight < 820.dp -> 356.dp
+                    else -> 392.dp
+                }
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Bottom,
+            ) {
+                Spacer(modifier = Modifier.weight(1f))
+                TableArena(
+                    uiState = uiState,
+                    modifier = Modifier.height(tableHeight),
+                )
+                Spacer(modifier = Modifier.height(2.dp))
+                PlayerArea(
+                    uiState = uiState,
+                    onToggleCardSelection = actions.onToggleCardSelection,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun TableArena(
+    uiState: MatchUiState,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(28.dp))
+            .background(Color(0xFF241612))
+            .padding(6.dp),
+    ) {
+        TableSurface(
+            modifier = Modifier.fillMaxSize(),
+        )
+        uiState.opponentSummaries.firstOrNull { it.seatId == TOP_SEAT_ID }?.let { opponent ->
+            OpponentSeatPanel(
+                opponent = opponent,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 4.dp)
+                    .offset(y = (-6).dp),
+            )
+        }
+        uiState.opponentSummaries.firstOrNull { it.seatId == LEFT_SEAT_ID }?.let { opponent ->
+            OpponentSeatPanel(
+                opponent = opponent,
+                modifier = Modifier
+                    .align(Alignment.CenterStart)
+                    .padding(start = 2.dp)
+                    .offset(x = (-6).dp, y = (-12).dp),
+            )
+        }
+        uiState.opponentSummaries.firstOrNull { it.seatId == RIGHT_SEAT_ID }?.let { opponent ->
+            OpponentSeatPanel(
+                opponent = opponent,
+                modifier = Modifier
+                    .align(Alignment.CenterEnd)
+                    .padding(end = 2.dp)
+                    .offset(x = 6.dp, y = (-12).dp),
+            )
+        }
+        val tablePlays =
+            if (uiState.tablePlays.isNotEmpty()) {
+                uiState.tablePlays
+            } else {
+                listOfNotNull(uiState.currentTablePlay)
+            }
+        tablePlays.forEach { tablePlay ->
+            SeatTablePlay(
+                tablePlay = tablePlay,
+                tableWidth = maxWidth,
+                tableHeight = maxHeight,
+            )
+        }
+        uiState.lastActionMessage?.let { message ->
+            ActionMessageBanner(
+                message = message,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopStart)
+                        .padding(start = 10.dp, top = 10.dp)
+                        .testTag(ComposeTestTags.ACTION_MESSAGE),
+            )
+        }
+    }
+}
+
+@Composable
+private fun TableSurface(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .clip(RoundedCornerShape(28.dp))
+            .background(TableFelt)
+            .border(width = 2.dp, color = TableBorder, shape = RoundedCornerShape(28.dp))
+            .padding(16.dp),
+    )
+}
+
+@Composable
+private fun ActionMessageBanner(
+    message: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(10.dp))
+            .background(Color(0xAA000000))
+            .padding(horizontal = 8.dp, vertical = 5.dp),
+    ) {
+        Text(
+            text = message,
+            color = Color.White,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}
+
+@Composable
+private fun BoxScope.SeatTablePlay(
+    tablePlay: TablePlaySummary,
+    tableWidth: Dp,
+    tableHeight: Dp,
+) {
+    val sideX = tableWidth * 0.13f
+    val sideY = tableHeight * 0.10f
+    val topY = tableHeight * 0.24f
+    val bottomY = tableHeight * 0.05f
+
+    val alignment =
+        when (tablePlay.ownerSeatId) {
+            LEFT_SEAT_ID -> Alignment.CenterStart
+            TOP_SEAT_ID -> Alignment.TopCenter
+            RIGHT_SEAT_ID -> Alignment.CenterEnd
+            else -> Alignment.BottomCenter
+        }
+
+    Row(
+        modifier = Modifier
+            .align(alignment)
+            .offset(
+                x =
+                    when (tablePlay.ownerSeatId) {
+                        LEFT_SEAT_ID -> sideX
+                        RIGHT_SEAT_ID -> -sideX
+                        else -> 0.dp
+                    },
+                y =
+                    when (tablePlay.ownerSeatId) {
+                        LEFT_SEAT_ID, RIGHT_SEAT_ID -> sideY
+                        TOP_SEAT_ID -> topY
+                        else -> -bottomY
+                    },
+            ),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        tablePlay.cardLabels.forEach { label ->
+            TableCard(label = label)
+        }
+    }
+}
+
+@Composable
+private fun OpponentSeatPanel(
+    opponent: OpponentSummary,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .width(100.dp)
+            .clip(RoundedCornerShape(14.dp))
+            .background(SeatPanel)
+            .border(1.dp, SeatPanelBorder, RoundedCornerShape(14.dp))
+            .padding(horizontal = 6.dp, vertical = 6.dp),
+        verticalArrangement = Arrangement.spacedBy(3.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = opponent.displayName,
+            color = Color(0xFFC6F6D5),
+            style = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+        )
+        Text(
+            text = stringResource(R.string.opponent_cards_left, opponent.remainingCards),
+            color = Color.White,
+            style = MaterialTheme.typography.labelSmall,
+        )
+        OpponentCardBacks(cardCount = opponent.remainingCards)
+        Text(
+            text =
+                when {
+                    opponent.isCurrentActor -> stringResource(R.string.opponent_current_actor)
+                    opponent.hasPassed -> stringResource(R.string.opponent_passed)
+                    else -> stringResource(R.string.opponent_waiting)
+                },
+            color = Color(0xFFE7D7B1),
+            style = MaterialTheme.typography.labelSmall,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun OpponentCardBacks(cardCount: Int) {
+    val visibleCount = cardCount.coerceAtMost(6)
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(1.dp),
+        modifier = Modifier.wrapContentWidth(),
+    ) {
+        repeat(visibleCount) {
+            Box(
+                modifier = Modifier
+                    .size(width = 9.dp, height = 15.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(CardBack)
+                    .border(1.dp, CardStroke, RoundedCornerShape(2.dp)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerArea(
+    uiState: MatchUiState,
+    onToggleCardSelection: (String) -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(24.dp))
+            .background(TableFelt)
+            .border(2.dp, TableBorder, RoundedCornerShape(24.dp))
+            .padding(horizontal = 12.dp, vertical = 14.dp),
+    ) {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(uiState.playerHand, key = { it.id }) { card ->
+                PlayerCardChip(
+                    card = card,
+                    isSelected = card.id in uiState.selectedCards,
+                    enabled = uiState.isHumanTurn,
+                    onToggle = { onToggleCardSelection(card.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BottomActionBar(
+    uiState: MatchUiState,
+    actions: GameScreenActions,
+) {
+    Surface(
+        color = WoodTint,
+        tonalElevation = 2.dp,
+        shadowElevation = 6.dp,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp, vertical = 0.dp),
+            verticalArrangement = Arrangement.spacedBy(0.dp),
+        ) {
+            GameActionButtons(uiState = uiState, actions = actions)
+        }
+    }
+}
+
+@Composable
+private fun GameActionButtons(
+    uiState: MatchUiState,
+    actions: GameScreenActions,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        ActionButton(
+            text = stringResource(R.string.clear_selection),
+            enabled = uiState.selectedCards.isNotEmpty(),
+            onClick = actions.onClearSelection,
+            tag = ComposeTestTags.CLEAR_SELECTION_BUTTON,
+        )
+        ActionButton(
+            text = stringResource(R.string.pass_turn),
+            enabled = uiState.canPass,
+            onClick = actions.onPassTurn,
+            tag = ComposeTestTags.PASS_BUTTON,
+        )
+        ActionButton(
+            text = stringResource(R.string.submit_play),
+            enabled = uiState.canSubmitPlay,
+            onClick = actions.onSubmitSelectedCards,
+            tag = ComposeTestTags.SUBMIT_BUTTON,
+            primary = true,
+        )
+    }
+}
+
+@Composable
+private fun RowScope.ActionButton(
+    text: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    tag: String,
+    primary: Boolean = false,
+) {
+    val buttonModifier = Modifier.weight(1f).testTag(tag)
+    if (primary) {
+        Button(
+            modifier = buttonModifier,
+            onClick = onClick,
+            enabled = enabled,
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    } else {
+        OutlinedButton(
+            modifier = buttonModifier,
+            onClick = onClick,
+            enabled = enabled,
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun TableCard(label: String) {
+    Box(
+        modifier = Modifier
+            .size(width = 42.dp, height = 58.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(CardFace)
+            .border(1.dp, CardStroke, RoundedCornerShape(8.dp)),
+        contentAlignment = Alignment.Center,
+    ) {
+        CardFaceContent(
+            label = label,
+            compact = true,
+        )
+    }
+}
+
+@Composable
+private fun PlayerCardChip(
+    card: GameCard,
+    isSelected: Boolean,
+    enabled: Boolean,
+    onToggle: () -> Unit,
+) {
+    val shape = RoundedCornerShape(8.dp)
+    val modifier =
+        Modifier
+            .size(width = 60.dp, height = 86.dp)
+            .offset(y = if (isSelected) (-10).dp else 0.dp)
+            .clip(shape)
+            .background(CardFace)
+            .border(
+                width = 2.dp,
+                color = if (isSelected) TableBorder else CardStroke,
+                shape = shape,
+            )
+            .clickable(enabled = enabled, onClick = onToggle)
+            .semantics {
+                contentDescription = card.displayName
+            }
+            .testTag("${ComposeTestTags.PLAYER_CARD_PREFIX}${card.id}")
+
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        CardFaceContent(
+            label = card.displayName,
+            compact = false,
+        )
+    }
+}
+
+@Composable
+private fun CardFaceContent(
+    label: String,
+    compact: Boolean = false,
+) {
+    val suit = label.takeLast(1)
+    val rank = label.dropLast(1)
+    val suitColor = if (suit == "\u2665" || suit == "\u2666") CardRed else CardBlack
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Text(
+            text = rank,
+            color = CardBlack,
+            style =
+                if (compact) {
+                    MaterialTheme.typography.bodyMedium
+                } else {
+                    MaterialTheme.typography.titleLarge
+                },
+            fontWeight = FontWeight.Bold,
+        )
+        Text(
+            text = suit,
+            color = suitColor,
+            style =
+                if (compact) {
+                    MaterialTheme.typography.bodyLarge
+                } else {
+                    MaterialTheme.typography.titleLarge
+                },
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}

--- a/app/src/main/java/com/example/chudadi/ui/game/GameScreenActions.kt
+++ b/app/src/main/java/com/example/chudadi/ui/game/GameScreenActions.kt
@@ -1,0 +1,8 @@
+package com.example.chudadi.ui.game
+
+data class GameScreenActions(
+    val onToggleCardSelection: (String) -> Unit,
+    val onClearSelection: () -> Unit,
+    val onSubmitSelectedCards: () -> Unit,
+    val onPassTurn: () -> Unit,
+)

--- a/app/src/main/java/com/example/chudadi/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/chudadi/ui/home/HomeScreen.kt
@@ -1,0 +1,55 @@
+package com.example.chudadi.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.chudadi.R
+import com.example.chudadi.ui.ComposeTestTags
+
+@Composable
+fun HomeScreen(
+    onStartLocalMatch: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(ComposeTestTags.HOME_SCREEN),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier.padding(24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.home_title),
+                style = MaterialTheme.typography.headlineMedium,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(R.string.home_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center,
+            )
+            Button(
+                modifier = Modifier.testTag(ComposeTestTags.START_MATCH_BUTTON),
+                onClick = onStartLocalMatch,
+            ) {
+                Text(text = stringResource(R.string.start_local_match))
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/chudadi/ui/result/ResultScreen.kt
+++ b/app/src/main/java/com/example/chudadi/ui/result/ResultScreen.kt
@@ -1,0 +1,66 @@
+package com.example.chudadi.ui.result
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.example.chudadi.R
+import com.example.chudadi.model.game.snapshot.MatchUiState
+import com.example.chudadi.ui.ComposeTestTags
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ResultScreen(
+    uiState: MatchUiState,
+    onRestartMatch: () -> Unit,
+    onExitToHome: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag(ComposeTestTags.RESULT_SCREEN),
+        topBar = {
+            TopAppBar(title = { Text(text = stringResource(R.string.result_title)) })
+        },
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(24.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.result_winner, uiState.resultSummary?.winnerName ?: "-"),
+                style = MaterialTheme.typography.headlineSmall,
+            )
+            uiState.resultSummary?.rankingLines.orEmpty().forEach { line ->
+                Text(text = line, style = MaterialTheme.typography.bodyLarge)
+            }
+            Button(
+                modifier = Modifier.testTag(ComposeTestTags.RESTART_BUTTON),
+                onClick = onRestartMatch,
+            ) {
+                Text(text = stringResource(R.string.restart_match))
+            }
+            Button(
+                modifier = Modifier.testTag(ComposeTestTags.EXIT_BUTTON),
+                onClick = onExitToHome,
+            ) {
+                Text(text = stringResource(R.string.exit_to_home))
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,26 @@
 <resources>
-    <string name="app_name">ChuDaDi</string>
+    <string name="app_name">锄大地</string>
+    <string name="home_title">锄大地单机对局</string>
+    <string name="home_subtitle">和 3 名规则型 AI 在同一台设备上完成一整局锄大地。</string>
+    <string name="start_local_match">开始本地对战</string>
+    <string name="game_title">对局中</string>
+    <string name="current_actor">当前行动者：%1$s</string>
+    <string name="current_table_play">当前桌面：%1$s - %2$s</string>
+    <string name="last_play_by">桌面出牌：%1$s · %2$s</string>
+    <string name="waiting_for_lead">当前桌面：等待新一轮领出</string>
+    <string name="your_hand">你的手牌</string>
+    <string name="player_status">你剩余手牌：%1$d</string>
+    <string name="selected_card_count">已选牌数：%1$d</string>
+    <string name="clear_selection">清空选牌</string>
+    <string name="pass_turn">过牌</string>
+    <string name="submit_play">出牌</string>
+    <string name="ai_turn_hint">AI 正在自动行动，请稍候。</string>
+    <string name="opponent_current_actor">当前行动中</string>
+    <string name="opponent_passed">本轮已过牌</string>
+    <string name="opponent_waiting">等待行动</string>
+    <string name="opponent_cards_left">剩余手牌：%1$d</string>
+    <string name="result_title">结算</string>
+    <string name="result_winner">胜者：%1$s</string>
+    <string name="restart_match">再来一局</string>
+    <string name="exit_to_home">返回入口</string>
 </resources>

--- a/app/src/test/java/com/example/chudadi/model/game/engine/GameEngineTest.kt
+++ b/app/src/test/java/com/example/chudadi/model/game/engine/GameEngineTest.kt
@@ -1,0 +1,62 @@
+package com.example.chudadi.model.game.engine
+
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.fixture.MatchFixtureFactory
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class GameEngineTest {
+    private val engine = GameEngine(random = Random(0))
+
+    @Test
+    fun startLocalMatch_dealsThirteenCardsAndPicksOpeningSeat() {
+        val match = engine.startLocalMatch()
+
+        assertEquals(4, match.seats.size)
+        assertTrue(match.seats.all { it.hand.size == 13 })
+        assertTrue(
+            match.seats
+                .first { it.seatId == match.activeSeatIndex }
+                .hand
+                .contains(Card(rank = CardRank.THREE, suit = CardSuit.DIAMONDS)),
+        )
+    }
+
+    @Test
+    fun submitSelectedCards_rejectsOpeningMoveWithoutDiamondThree() {
+        val match = MatchFixtureFactory.localMatch(activeSeatIndex = 0)
+
+        val result = engine.submitSelectedCards(
+            match = match,
+            seatIndex = 0,
+            selectedCardIds = setOf(MatchFixtureFactory.card(CardRank.FOUR, CardSuit.CLUBS).id),
+        )
+
+        assertFalse(result.success)
+        assertEquals(GameActionError.OPENING_MOVE_MUST_CONTAIN_DIAMOND_THREE, result.error)
+        assertNull(result.message)
+    }
+
+    @Test
+    fun submitSelectedCards_acceptsOpeningMoveWithDiamondThree() {
+        val match = MatchFixtureFactory.localMatch(activeSeatIndex = 0)
+
+        val result = engine.submitSelectedCards(
+            match = match,
+            seatIndex = 0,
+            selectedCardIds = setOf(MatchFixtureFactory.card(CardRank.THREE, CardSuit.DIAMONDS).id),
+        )
+
+        assertTrue(result.success)
+        assertNull(result.error)
+        assertNotNull(result.match.trickState.currentCombination)
+        assertEquals(2, result.match.seats.first { it.seatId == 0 }.hand.size)
+    }
+}

--- a/app/src/test/java/com/example/chudadi/model/game/engine/GameTurnRulesTest.kt
+++ b/app/src/test/java/com/example/chudadi/model/game/engine/GameTurnRulesTest.kt
@@ -1,0 +1,98 @@
+package com.example.chudadi.model.game.engine
+
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.fixture.MatchFixtureFactory
+import com.example.chudadi.model.game.rule.CombinationEvaluator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class GameTurnRulesTest {
+    private val engine = GameEngine()
+    private val evaluator = CombinationEvaluator()
+
+    @Test
+    fun passTurn_rejectsLeadingPlayer() {
+        val match = MatchFixtureFactory.localMatch(activeSeatIndex = 0)
+
+        val result = engine.passTurn(match = match, seatIndex = 0)
+
+        assertFalse(result.success)
+        assertEquals(GameActionError.CANNOT_PASS_LEAD_TURN, result.error)
+    }
+
+    @Test
+    fun submitSelectedCards_rejectsSmallerSingle() {
+        val baseMatch = MatchFixtureFactory.localMatch(activeSeatIndex = 0)
+        val currentCombination = evaluator.parse(
+            listOf(MatchFixtureFactory.card(CardRank.FIVE, CardSuit.SPADES)),
+        )
+        val match = baseMatch.copy(
+            trickState = baseMatch.trickState.copy(
+                currentCombination = currentCombination,
+                lastWinningSeatIndex = 1,
+            ),
+        )
+
+        val result = engine.submitSelectedCards(
+            match = match,
+            seatIndex = 0,
+            selectedCardIds = setOf(MatchFixtureFactory.card(CardRank.THREE, CardSuit.DIAMONDS).id),
+        )
+
+        assertFalse(result.success)
+        assertEquals(GameActionError.PLAY_DOES_NOT_BEAT_CURRENT, result.error)
+    }
+
+    @Test
+    fun passTurn_resetsRoundAfterAllOtherActiveSeatsPass() {
+        val baseMatch = MatchFixtureFactory.localMatch(activeSeatIndex = 1)
+        val currentCombination = evaluator.parse(
+            listOf(MatchFixtureFactory.card(CardRank.FIVE, CardSuit.SPADES)),
+        )
+        val match = baseMatch.copy(
+            trickState = baseMatch.trickState.copy(
+                currentCombination = currentCombination,
+                lastWinningSeatIndex = 0,
+            ),
+        )
+
+        val afterFirstPass = engine.passTurn(match = match, seatIndex = 1).match
+        val afterSecondPass = engine.passTurn(match = afterFirstPass, seatIndex = 2).match
+        val afterThirdPass = engine.passTurn(match = afterSecondPass, seatIndex = 3).match
+
+        assertEquals(MatchPhase.ROUND_RESET, afterThirdPass.phase)
+        assertEquals(0, afterThirdPass.activeSeatIndex)
+        assertNull(afterThirdPass.trickState.currentCombination)
+        assertTrue(afterThirdPass.seats.filter { it.seatId != 0 }.all { it.status.name == "ACTIVE" })
+    }
+
+    @Test
+    fun passTurn_clearsPassedSeatTablePlay_andShowsBuYaoMessage() {
+        val baseMatch = MatchFixtureFactory.localMatch(activeSeatIndex = 1)
+        val combination = evaluator.parse(
+            listOf(MatchFixtureFactory.card(CardRank.FIVE, CardSuit.SPADES)),
+        )!!
+        val match = baseMatch.copy(
+            trickState = baseMatch.trickState.copy(
+                currentCombination = combination,
+                lastWinningSeatIndex = 0,
+                tablePlays = mapOf(
+                    0 to combination,
+                    1 to combination,
+                ),
+            ),
+        )
+
+        val result = engine.passTurn(match = match, seatIndex = 1)
+
+        assertTrue(result.success)
+        assertEquals("AI 1 要不起", result.message)
+        assertFalse(result.match.trickState.tablePlays.containsKey(1))
+        assertTrue(result.match.trickState.tablePlays.containsKey(0))
+    }
+}

--- a/app/src/test/java/com/example/chudadi/model/game/engine/RestartMatchTest.kt
+++ b/app/src/test/java/com/example/chudadi/model/game/engine/RestartMatchTest.kt
@@ -1,0 +1,21 @@
+package com.example.chudadi.model.game.engine
+
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import kotlin.random.Random
+
+class RestartMatchTest {
+    @Test
+    fun startLocalMatch_createsFreshMatchStateEachTime() {
+        val engine = GameEngine(random = Random(1))
+
+        val firstMatch = engine.startLocalMatch()
+        val secondMatch = engine.startLocalMatch()
+
+        assertNotEquals(firstMatch.matchId, secondMatch.matchId)
+        assertNull(secondMatch.result)
+        assertTrue(secondMatch.seats.all { it.hand.size == 13 })
+    }
+}

--- a/app/src/test/java/com/example/chudadi/model/game/fixture/MatchFixtureFactory.kt
+++ b/app/src/test/java/com/example/chudadi/model/game/fixture/MatchFixtureFactory.kt
@@ -1,0 +1,73 @@
+package com.example.chudadi.model.game.fixture
+
+import com.example.chudadi.model.game.entity.Card
+import com.example.chudadi.model.game.entity.CardRank
+import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.Seat
+import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.entity.SeatStatus
+import com.example.chudadi.model.game.entity.TrickState
+
+object MatchFixtureFactory {
+    fun card(
+        rank: CardRank,
+        suit: CardSuit,
+    ): Card = Card(rank = rank, suit = suit)
+
+    fun localMatch(
+        activeSeatIndex: Int = 0,
+        seats: List<Seat> = defaultSeats(),
+    ): Match {
+        return Match(
+            matchId = "fixture-match",
+            phase = MatchPhase.PLAYER_TURN,
+            seats = seats,
+            activeSeatIndex = activeSeatIndex,
+            trickState = TrickState(
+                leadSeatIndex = activeSeatIndex,
+                lastWinningSeatIndex = activeSeatIndex,
+                currentCombination = null,
+                passCount = 0,
+                roundNumber = 1,
+            ),
+            playHistory = emptyList(),
+            result = null,
+        )
+    }
+
+    fun defaultSeats(): List<Seat> {
+        return listOf(
+            Seat(
+                seatId = 0,
+                displayName = "You",
+                controllerType = SeatControllerType.HUMAN,
+                hand = listOf(
+                    card(CardRank.THREE, CardSuit.DIAMONDS),
+                    card(CardRank.FOUR, CardSuit.CLUBS),
+                    card(CardRank.FIVE, CardSuit.HEARTS),
+                ),
+                status = SeatStatus.ACTIVE,
+            ),
+            Seat(
+                seatId = 1,
+                displayName = "AI 1",
+                controllerType = SeatControllerType.RULE_BASED_AI,
+                hand = listOf(card(CardRank.SIX, CardSuit.SPADES)),
+            ),
+            Seat(
+                seatId = 2,
+                displayName = "AI 2",
+                controllerType = SeatControllerType.RULE_BASED_AI,
+                hand = listOf(card(CardRank.SEVEN, CardSuit.DIAMONDS)),
+            ),
+            Seat(
+                seatId = 3,
+                displayName = "AI 3",
+                controllerType = SeatControllerType.RULE_BASED_AI,
+                hand = listOf(card(CardRank.EIGHT, CardSuit.CLUBS)),
+            ),
+        )
+    }
+}

--- a/docs/仓库初始化指南.md
+++ b/docs/仓库初始化指南.md
@@ -126,3 +126,52 @@ sh scripts/install-hooks.sh
 - `./gradlew.bat lintFix`
 
 修复后重新提交即可。
+
+## 8. APK 打包命令
+
+### 8.1 打包 Debug APK
+
+```bash
+./gradlew.bat assembleDebug --no-daemon --console=plain
+```
+默认输出：
+- `app/build/outputs/apk/debug/app-debug.apk`
+
+### 8.2 打包 Release APK
+```bash
+./gradlew.bat assembleRelease --no-daemon --console=plain
+```
+当前项目启用了 ABI 拆分，Release 输出：
+- `app/build/outputs/apk/release/app-arm64-v8a-release-unsigned.apk`
+- `app/build/outputs/apk/release/app-armeabi-v7a-release-unsigned.apk`
+
+## 9. Release 签名配置
+
+### 9.1 生成签名证书（示例）
+```bash
+mkdir keystore
+keytool -genkeypair -v -keystore keystore/chudadi-release.p12 -storetype PKCS12 -keyalg RSA -keysize 2048 -validity 36500 -alias chudadi
+```
+
+若出现 `java.io.FileNotFoundException: keystore\\chudadi-release.p12`，表示 `keystore` 目录不存在，请先创建目录再执行 `keytool`。
+
+若你已经创建了 `JKS` 文件并出现迁移警告，可执行：
+
+```bash
+keytool -importkeystore -srckeystore keystore/chudadi-release.jks -destkeystore keystore/chudadi-release.p12 -deststoretype PKCS12
+```
+
+### 9.2 配置 keystore.properties
+将项目根目录下的 `keystore.properties.example` 复制为 `keystore.properties`，并填写真实值：
+```properties
+storeFile=keystore/chudadi-release.p12
+storePassword=你的_store_password
+keyAlias=chudadi
+keyPassword=你的_key_password
+```
+说明：`keystore.properties` 已加入 `.gitignore`，不会被提交到仓库。
+
+### 9.3 打包签名 Release APK
+```bash
+./gradlew.bat assembleRelease --no-daemon --console=plain
+```

--- a/keystore.properties.example
+++ b/keystore.properties.example
@@ -1,0 +1,8 @@
+﻿# Copy this file to keystore.properties and fill real values.
+# Do not commit keystore.properties.
+# storeFile can be relative to project root or an absolute path.
+# Recommended format: PKCS12 (.p12)
+storeFile=keystore/chudadi-release.p12
+storePassword=replace_with_store_password
+keyAlias=chudadi
+keyPassword=replace_with_key_password


### PR DESCRIPTION
## 背景
- 基于 `docs/Android 蓝牙锄大地游戏技术架构文档.md` 完成 MVP 第一版落地。
- 当前阶段目标：基础框架 + 规则型AI。

## 本次改动
1. 领域与规则
- 新增核心实体：`Match / Seat / TrickState / PlayCombination`。
- 新增规则引擎：发牌、轮转、出牌校验、过牌与结算。

2. 客户端与状态映射
- 新增本地控制器与权威控制器，统一指令入口（出牌/过牌）。
- 新增 `MatchUiStateMapper`，将领域模型映射到 UI 状态。

3. UI 与交互
- 新增 `GameScreen`、`HomeScreen`、`ResultScreen`。
- 支持选牌、出牌、过牌、提示信息与结果展示。

4. AI
- 新增规则型 AI，支持在本地对局中自动行动。

5. 测试
- 新增引擎单测（回合规则、出牌合法性、重开等）。

## 关键设计对齐
- [x] 单 Android 模块优先
- [x] 规则校验与结算走可测试域模型
- [x] 命令式交互入口（便于后续蓝牙 C/S 扩展）

## 风险与后续
- 风险：此版本为 MVP，大部分边界情况尚未覆盖，各模块均未实现。
- 后续：
    - 规则引擎迭代，补齐规则与判断。
    - CS架构蓝牙联机，补齐协议与状态同步测试。
    - ui重构，逐步完善动画、特效与交互细节。
    - 界面设计迭代，提升用户体验。
    - 引入音乐与音效，增强游戏氛围。
    - 逐步引入更复杂的 AI（如基于 ONNX 的推理 AI）。