### PR TITLE
feat(Alplayer): 增强规则人机 (CDD-43)

### DIFF
--- a/app/src/main/java/com/example/chudadi/ai/rulebased/RuleBasedAiPlayer.kt
+++ b/app/src/main/java/com/example/chudadi/ai/rulebased/RuleBasedAiPlayer.kt
@@ -6,6 +6,7 @@ import com.example.chudadi.model.game.rule.CombinationEvaluator
 import com.example.chudadi.model.game.entity.Card
 import com.example.chudadi.model.game.entity.CardRank
 import com.example.chudadi.model.game.entity.CardSuit
+import com.example.chudadi.model.game.rule.CombinationType
 
 sealed interface AiDecision {
     data class Play(
@@ -41,21 +42,34 @@ class RuleBasedAiPlayer(
     }
 
     private fun chooseLeadCombination(combinations: List<PlayCombination>): PlayCombination? {
-        val openingCard = Card(suit = CardSuit.DIAMONDS, rank = CardRank.THREE)
-        val openingCandidates = combinations.filter { combination ->
-            combination.cards.any { it.id == openingCard.id }
+        val cardsWithThreeOfDiamonds = combinations.filter { combination ->
+            combination.cards.contains(Card(CardSuit.DIAMONDS, CardRank.THREE)) &&
+                combination.cards.size > 1
         }
-        val candidatePool = if (openingCandidates.isNotEmpty()) openingCandidates else combinations
 
-        return candidatePool
-            .filter { it.cardCount == 1 }
-            .minWithOrNull(compareBy<PlayCombination> { it.primaryRank }.thenBy { it.primarySuit })
-            ?: candidatePool.minWithOrNull(
-                compareBy<PlayCombination> { it.cardCount }
-                    .thenBy { it.type.typePower }
-                    .thenBy { it.primaryRank }
-                    .thenBy { it.primarySuit },
-            )
+        if (cardsWithThreeOfDiamonds.isNotEmpty()) {
+            return cardsWithThreeOfDiamonds.random()
+        }
+
+        val singleThreeOfDiamonds = combinations.filter { combination ->
+            combination.cards.contains(Card(CardSuit.DIAMONDS, CardRank.THREE)) &&
+                combination.cards.size == 1
+        }
+
+        if (singleThreeOfDiamonds.isNotEmpty()) {
+            return singleThreeOfDiamonds.first()
+        }
+        
+        return if ((0..1).random() == 0) {
+            combinations
+                .sortedWith(
+                    compareByDescending<PlayCombination> { it.type.typePower }
+                        .thenBy { it.primaryRank }
+                )
+                .firstOrNull()
+        } else {
+            combinations.randomOrNull()
+        }
     }
 
     private fun chooseResponseCombination(


### PR DESCRIPTION
**总结：**
- 完善规则人机出牌逻辑，优化 AI 首发选择和牌型判断。
- 引入新的出牌策略，包括引入加权随机选择和牌型优先级排序。
- 增强 AI 决策的多样性，避免单一模式出牌。

**本次改动：**
- 出牌策略： 优化 `chooseLeadCombination `函数，避免 AI 在首发时因MVP原则而只选择出单张，且增加更多灵活的策略选择。
- 牌型优先级： 引入牌型优先级排序，避免 AI 总是选择最小牌。
- 随机选择： 加入加权随机策略，避免每次出牌模式固定：50%的概率选择最大合法牌型的最小点数，50%的概率从合法的牌型中随机选择。

@oeasy1412 @MikeHuang2000 帮忙review一下这个PR