### PR TITLE
fix(ui): 修复UI界面切换规则问题  CDD-48

### DIFF
--- a/app/src/main/java/com/example/chudadi/controller/client/LocalPlayerController.kt
+++ b/app/src/main/java/com/example/chudadi/controller/client/LocalPlayerController.kt
@@ -6,6 +6,8 @@ import com.example.chudadi.controller.game.MatchUiStateMapper
 import com.example.chudadi.controller.server.LocalAuthoritativeController
 import com.example.chudadi.model.game.entity.Match
 import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.rule.GameRuleSet
 import com.example.chudadi.model.game.snapshot.MatchUiState
 import com.example.chudadi.network.protocol.PassCommand
 import com.example.chudadi.network.protocol.PlayCardCommand
@@ -32,18 +34,19 @@ class LocalPlayerController(
     private var localSeatId: Int = MatchUiStateMapper.DEFAULT_LOCAL_SEAT_ID
 
     fun onRequestStartLocalMatch(
-        seatConfigs: List<Triple<Int, String, com.example.chudadi.model.game.entity.SeatControllerType>>? = null,
+        seatConfigs: List<Triple<Int, String, SeatControllerType>>? = null,
         localSeatId: Int = 0,
+        ruleSet: GameRuleSet = GameRuleSet.SOUTHERN,
     ) {
         aiTurnJob?.cancel()
         this.localSeatId = localSeatId
         currentMatch = if (seatConfigs != null) {
             serverController.startLocalMatch(
-                ruleSet = com.example.chudadi.model.game.rule.GameRuleSet.SOUTHERN,
+                ruleSet = ruleSet,
                 seatConfigs = seatConfigs,
             )
         } else {
-            serverController.startLocalMatch()
+            serverController.startLocalMatch(ruleSet)
         }
         selectedCardIds = emptySet()
         lastActionMessage = null

--- a/app/src/main/java/com/example/chudadi/controller/game/LocalGameAction.kt
+++ b/app/src/main/java/com/example/chudadi/controller/game/LocalGameAction.kt
@@ -1,11 +1,13 @@
 package com.example.chudadi.controller.game
 
 import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.rule.GameRuleSet
 
 sealed interface LocalGameAction {
     data class StartLocalMatch(
         val seatConfigs: List<Triple<Int, String, SeatControllerType>>? = null,
         val localSeatId: Int = 0,
+        val ruleSet: GameRuleSet = GameRuleSet.SOUTHERN,
     ) : LocalGameAction
     data class ToggleCardSelection(val cardId: String) : LocalGameAction
     data object ClearSelection : LocalGameAction

--- a/app/src/main/java/com/example/chudadi/controller/game/LocalMatchViewModel.kt
+++ b/app/src/main/java/com/example/chudadi/controller/game/LocalMatchViewModel.kt
@@ -39,7 +39,11 @@ class LocalMatchViewModel(
     fun dispatch(action: LocalGameAction) {
         when (action) {
             is LocalGameAction.StartLocalMatch ->
-                controller.onRequestStartLocalMatch(action.seatConfigs, action.localSeatId)
+                controller.onRequestStartLocalMatch(
+                    seatConfigs = action.seatConfigs,
+                    localSeatId = action.localSeatId,
+                    ruleSet = action.ruleSet,
+                )
             LocalGameAction.ClearSelection -> controller.onClearSelection()
             LocalGameAction.SubmitSelectedCards -> controller.onRequestPlayCards()
             LocalGameAction.PassTurn -> controller.onRequestPass()

--- a/app/src/main/java/com/example/chudadi/navigation/ChuDaDiNavGraph.kt
+++ b/app/src/main/java/com/example/chudadi/navigation/ChuDaDiNavGraph.kt
@@ -12,11 +12,13 @@ import com.example.chudadi.controller.game.LocalGameAction
 import com.example.chudadi.controller.game.LocalMatchViewModel
 import com.example.chudadi.model.game.entity.MatchPhase
 import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.rule.GameRuleSet
 import com.example.chudadi.model.game.snapshot.MatchUiState
 import com.example.chudadi.ui.game.GameScreen
 import com.example.chudadi.ui.game.GameScreenActions
 import com.example.chudadi.ui.home.HomeScreen
 import com.example.chudadi.ui.result.ResultScreen
+import com.example.chudadi.ui.room.GameRuleDisplay
 import com.example.chudadi.ui.room.RoomAction
 import com.example.chudadi.ui.room.RoomScreen
 import com.example.chudadi.ui.room.RoomUiState
@@ -132,7 +134,15 @@ private fun buildStartMatchAction(roomUiState: RoomUiState): LocalGameAction.Sta
             Triple(slot.seatId, name, controllerType)
         }
     val localSeatId = roomUiState.slots.firstOrNull { it.isLocalPlayer }?.seatId ?: return null
-    return LocalGameAction.StartLocalMatch(seatConfigs, localSeatId)
+    val ruleSet = when (roomUiState.currentRule) {
+        GameRuleDisplay.SOUTHERN -> GameRuleSet.SOUTHERN
+        GameRuleDisplay.NORTHERN -> GameRuleSet.NORTHERN
+    }
+    return LocalGameAction.StartLocalMatch(
+        seatConfigs = seatConfigs,
+        localSeatId = localSeatId,
+        ruleSet = ruleSet,
+    )
 }
 
 private fun RoomUiState.canStartMatch(): Boolean {

--- a/app/src/test/java/com/example/chudadi/controller/client/LocalPlayerControllerTest.kt
+++ b/app/src/test/java/com/example/chudadi/controller/client/LocalPlayerControllerTest.kt
@@ -1,0 +1,60 @@
+package com.example.chudadi.controller.client
+
+import com.example.chudadi.ai.rulebased.RuleBasedAiPlayer
+import com.example.chudadi.controller.game.MatchUiStateMapper
+import com.example.chudadi.controller.server.LocalAuthoritativeController
+import com.example.chudadi.model.game.engine.GameEngine
+import com.example.chudadi.model.game.entity.Match
+import com.example.chudadi.model.game.entity.MatchPhase
+import com.example.chudadi.model.game.entity.SeatControllerType
+import com.example.chudadi.model.game.fixture.MatchFixtureFactory
+import com.example.chudadi.model.game.rule.GameRuleSet
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LocalPlayerControllerTest {
+    @Test
+    fun startLocalMatch_forwardsSelectedRuleSetToEngine() {
+        val engine = CapturingGameEngine()
+        val controller = LocalPlayerController(
+            serverController = LocalAuthoritativeController(engine),
+            aiPlayer = RuleBasedAiPlayer(),
+            mapper = MatchUiStateMapper(engine),
+            scope = CoroutineScope(Dispatchers.Unconfined),
+        )
+        val seatConfigs = listOf(
+            Triple(0, "You", SeatControllerType.HUMAN),
+            Triple(1, "AI 1", SeatControllerType.RULE_BASED_AI),
+            Triple(2, "AI 2", SeatControllerType.RULE_BASED_AI),
+            Triple(3, "AI 3", SeatControllerType.RULE_BASED_AI),
+        )
+
+        controller.onRequestStartLocalMatch(
+            seatConfigs = seatConfigs,
+            localSeatId = 0,
+            ruleSet = GameRuleSet.NORTHERN,
+        )
+
+        assertEquals(GameRuleSet.NORTHERN, engine.capturedRuleSet)
+        assertEquals(MatchPhase.PLAYER_TURN, controller.uiState.value.phase)
+    }
+
+    private class CapturingGameEngine : GameEngine() {
+        var capturedRuleSet: GameRuleSet? = null
+
+        override fun startLocalMatch(ruleSet: GameRuleSet): Match {
+            capturedRuleSet = ruleSet
+            return MatchFixtureFactory.localMatch(ruleSet = ruleSet)
+        }
+
+        override fun startLocalMatch(
+            ruleSet: GameRuleSet,
+            seatConfigs: List<Triple<Int, String, SeatControllerType>>,
+        ): Match {
+            capturedRuleSet = ruleSet
+            return MatchFixtureFactory.localMatch(ruleSet = ruleSet)
+        }
+    }
+}


### PR DESCRIPTION
# 主要改了 **“房间 UI 选择南/北规则后，实际开局没有生效”** 这个问题。

## 修改说明

- 修复规则选择传递链路：
  - 房间界面的 `currentRule` 现在会在开始游戏时转换成 `GameRuleSet.SOUTHERN` 或 `GameRuleSet.NORTHERN`。
  - `StartLocalMatch` action 增加了 `ruleSet` 参数。
  - `LocalMatchViewModel` 会把 `ruleSet` 继续传给本地游戏 controller。
  - `LocalPlayerController` 不再硬编码使用南方规则，而是使用 UI 传入的规则开局。

- 没有改动规则/计分核心逻辑，只是把 UI 选择的规则正确传到已有引擎逻辑里。

- 新增测试：
  - 新增 `LocalPlayerControllerTest`
  - 覆盖“选择北方规则开局时，controller 会把 `GameRuleSet.NORTHERN` 传给引擎”。

## 验证结果

- `testDebugUnitTest` 通过
- 新增的 `LocalPlayerControllerTest` 通过
- `ktlintCheck` 通过
- `detekt` 通过

## 当前效果

房间里切换到北方规则后，再开始游戏，实际游戏规则和计分会按北方规则执行；南方规则仍保持原来的默认行为。